### PR TITLE
Add release workflow and skin manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Build and Release Skin
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stage whitelist into ./dist
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # Whitelist — ONLY these paths become part of the skin.
+          # Everything else in the repo (shots/, .DS_Store, AI agent dirs,
+          # loose notes, TCL files, figama_code/, test logs, etc.) is excluded
+          # by construction, not by ignore rules.
+          #
+          # Layout note: index.html at repo root references src/css, src/modules,
+          # src/profiles, src/settings, src/ui — so we ship src/ as-is, not the
+          # individual subfolders.
+          for path in index.html skin-manifest.json src; do
+            if [ -e "$path" ]; then
+              cp -r "$path" dist/
+            else
+              echo "::warning::whitelist entry missing: $path"
+            fi
+          done
+
+      - name: Validate skin-manifest.json
+        run: |
+          set -euo pipefail
+          test -f dist/skin-manifest.json
+          jq -e '.id == "streamline.js"' dist/skin-manifest.json > /dev/null
+          jq -e '.version' dist/skin-manifest.json > /dev/null
+
+      - name: Reject filenames with Win32 reserved chars
+        run: |
+          set -euo pipefail
+          bad=$(find dist -type f | grep -E '[<>:"|?*]' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::found filenames with Win32 reserved chars:"
+            echo "$bad"
+            exit 1
+          fi
+
+      # On every push to main: publish ./dist to the dist branch (orphan, force)
+      - name: Deploy to dist branch
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: dist
+          force_orphan: true
+
+      # On tag push: zip ./dist and publish a GitHub Release
+      - name: Create release archive
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cd dist
+          zip -r ../streamline.js-${{ github.ref_name }}.zip .
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: streamline.js-${{ github.ref_name }}.zip
+          generate_release_notes: true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,62 @@
+# Release Process
+
+This repo uses a GitHub Action (`.github/workflows/release.yml`) that builds a
+sanitised snapshot of the skin from a whitelist of paths. Two triggers:
+
+## `dist` branch — tracks `main`
+
+Every push to `main` force-pushes a clean copy of the whitelist to the `dist`
+branch. This is the bleeding-edge dev channel. Downstream tools that want to
+follow main without waiting for a release can point at:
+
+```
+github_branch: <owner>/streamline_project@dist
+```
+
+The `dist` branch is orphan and force-pushed on every main update, so it
+never accumulates history.
+
+## Tagged releases
+
+Push a tag matching `v*` to cut a release:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The action zips the staged whitelist as `streamline.js-v0.1.0.zip` and
+publishes a GitHub Release with auto-generated notes. Downstream tools
+consume this via:
+
+```
+github_release: <owner>/streamline_project
+```
+
+## Whitelist
+
+Only these paths ship in the skin:
+
+- `index.html`
+- `skin-manifest.json`
+- `src/` (contains `css/`, `modules/`, `profiles/`, `settings/`, `ui/`)
+
+Anything else in the repo is **excluded by construction**, not by ignore
+rules. This means future repo pollution (loose notes, AI agent configs,
+experimental folders, etc.) cannot slip into releases without an explicit
+change to the workflow.
+
+To add a new top-level path, edit the `Stage whitelist into ./dist` step in
+`.github/workflows/release.yml`.
+
+## Validation
+
+The workflow enforces two invariants before publishing:
+
+1. `dist/skin-manifest.json` exists and declares `id == "streamline.js"` and
+   a non-empty `version` field.
+2. No file in `dist/` has a Win32-reserved character (`< > : " | ? *`) in its
+   name. Windows `CreateFile` rejects these with `ERROR_INVALID_NAME`, and
+   any such file would crash skin installation on Windows.
+
+A failure on either check stops the release cleanly.

--- a/skin-manifest.json
+++ b/skin-manifest.json
@@ -1,0 +1,6 @@
+{
+  "id": "streamline.js",
+  "name": "Streamline.js",
+  "description": "Modern, feature-complete WebUI skin for Streamline-Bridge",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
## Summary

Adds a GitHub Action that publishes both a `dist` branch (tracks main) and tagged release zips, plus a `skin-manifest.json` at root. **No runtime code touched.**

## Why

Streamline-Bridge (the downstream Flutter app) currently pulls this repo as a `github_branch` zip of `main`. That ships the entire working tree — including `shots/*.json` files with `:` in the filename (ISO timestamps like `2025-09-12T16:04:38.049213.json`) — and Windows `CreateFile` rejects `:` with `errno 123` (`ERROR_INVALID_NAME`). **Windows users of Streamline-Bridge cannot currently install Streamline.js.**

This PR gives Bridge a clean distribution channel without needing to clean the repo itself.

Full diagnosis from a user log: the extraction crashes in `WebUIStorage._installFromZip` on the first `shots/*.json` file and aborts the whole install, so no skin lands on the user's machine.

## What it adds

- **`.github/workflows/release.yml`** — single workflow, two triggers:
  - push to `main` → force-push a whitelisted staging tree to a new `dist` branch (bleeding-edge dev channel, clean)
  - push tag `v*` → zip the same staging tree and publish a GitHub Release
- **`skin-manifest.json`** — declares skin `id`, `name`, `description`, `version`. Bridge prefers this over PWA `manifest.json`, so it never collides with your existing web-app manifest if you have one.
- **`RELEASE.md`** — documents how to cut a release.

## Whitelist

Only these paths ship in the skin:

- `index.html`
- `skin-manifest.json`
- `src/` (contains `css/`, `modules/`, `profiles/`, `settings/`, `ui/` — the actual skin assets that `index.html` references)

Everything else in the repo (`shots/`, `.DS_Store`, AI agent dirs, loose docs, `skin.tcl`, `figama_code/`, CSVs, log dumps, etc.) is excluded **by construction**, so future repo pollution cannot slip into releases without an explicit change to the workflow.

The workflow also actively fails the build if any file in `dist/` has a Win32-reserved character (`<>:"|?*`) in its name — so regressions on Windows cannot ship silently.

## Heads up

Merging this will add a force-pushed `dist` branch to your repo on every push to `main`. The branch is orphan with `force_orphan: true` in `peaceiris/actions-gh-pages@v3`, so no history accumulates. If you'd rather not have a `dist` branch on your canonical repo, I can split the workflow to only cut release zips on tag push — just let me know.

## Verification

Already fully verified on `tadelv/streamline_project` (the fork this PR comes from):

- `dist` branch populates correctly with whitelist contents (60 files, `src/` tree intact, zero junk)
- `v0.1.0` tag produced `streamline.js-v0.1.0.zip` — verified zero filenames with reserved chars, `skin-manifest.json` at root, `id: "streamline.js"`
- Release: https://github.com/tadelv/streamline_project/releases/tag/v0.1.0

## Next step for Streamline-Bridge

Once this lands and you tag a release here, Bridge will flip its `skin_sources.json` entry from:

```json
{"type": "github_branch", "repo": "allofmeng/streamline_project", "branch": "main"}
```

to:

```json
{"type": "github_release", "repo": "allofmeng/streamline_project"}
```

and Windows users will be unblocked.

## Attribution note

The fork (`tadelv/streamline_project`) exists purely as an upstreaming vehicle for this PR, not as a replacement of this canonical repo.