### PR TITLE
feat(release): sync skin-manifest.json version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Build and Release Skin
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stage whitelist into ./dist
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # Whitelist — ONLY these paths become part of the skin.
+          # Everything else in the repo (shots/, .DS_Store, AI agent dirs,
+          # loose notes, TCL files, figama_code/, test logs, etc.) is excluded
+          # by construction, not by ignore rules.
+          #
+          # Layout note: index.html at repo root references src/css, src/modules,
+          # src/profiles, src/settings, src/ui — so we ship src/ as-is, not the
+          # individual subfolders.
+          for path in index.html skin-manifest.json src; do
+            if [ -e "$path" ]; then
+              cp -r "$path" dist/
+            else
+              echo "::warning::whitelist entry missing: $path"
+            fi
+          done
+
+      - name: Validate skin-manifest.json
+        run: |
+          set -euo pipefail
+          test -f dist/skin-manifest.json
+          jq -e '.id == "streamline.js"' dist/skin-manifest.json > /dev/null
+          jq -e '.version' dist/skin-manifest.json > /dev/null
+
+      - name: Reject filenames with Win32 reserved chars
+        run: |
+          set -euo pipefail
+          bad=$(find dist -type f | grep -E '[<>:"|?*]' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::found filenames with Win32 reserved chars:"
+            echo "$bad"
+            exit 1
+          fi
+
+      # On every push to main: publish ./dist to the dist branch (orphan, force)
+      - name: Deploy to dist branch
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: dist
+          force_orphan: true
+
+      # On tag push: zip ./dist and publish a GitHub Release
+      - name: Create release archive
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cd dist
+          zip -r ../streamline.js-${{ github.ref_name }}.zip .
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: streamline.js-${{ github.ref_name }}.zip
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,20 @@ jobs:
             fi
           done
 
+      # On tag builds, rewrite the manifest version from the git tag so the
+      # tag is the single source of truth. Maintainer only has to `git tag vX.Y.Z`
+      # and the release zip's skin-manifest.json is auto-synced. On main pushes
+      # (dist branch deploys) the manifest stays as committed.
+      - name: Sync skin-manifest.json version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          jq --arg v "$version" '.version = $v' dist/skin-manifest.json > dist/skin-manifest.json.tmp
+          mv dist/skin-manifest.json.tmp dist/skin-manifest.json
+          echo "Synced manifest version to: $version"
+          cat dist/skin-manifest.json
+
       - name: Validate skin-manifest.json
         run: |
           set -euo pipefail

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,62 @@
+# Release Process
+
+This repo uses a GitHub Action (`.github/workflows/release.yml`) that builds a
+sanitised snapshot of the skin from a whitelist of paths. Two triggers:
+
+## `dist` branch — tracks `main`
+
+Every push to `main` force-pushes a clean copy of the whitelist to the `dist`
+branch. This is the bleeding-edge dev channel. Downstream tools that want to
+follow main without waiting for a release can point at:
+
+```
+github_branch: <owner>/streamline_project@dist
+```
+
+The `dist` branch is orphan and force-pushed on every main update, so it
+never accumulates history.
+
+## Tagged releases
+
+Push a tag matching `v*` to cut a release:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The action zips the staged whitelist as `streamline.js-v0.1.0.zip` and
+publishes a GitHub Release with auto-generated notes. Downstream tools
+consume this via:
+
+```
+github_release: <owner>/streamline_project
+```
+
+## Whitelist
+
+Only these paths ship in the skin:
+
+- `index.html`
+- `skin-manifest.json`
+- `src/` (contains `css/`, `modules/`, `profiles/`, `settings/`, `ui/`)
+
+Anything else in the repo is **excluded by construction**, not by ignore
+rules. This means future repo pollution (loose notes, AI agent configs,
+experimental folders, etc.) cannot slip into releases without an explicit
+change to the workflow.
+
+To add a new top-level path, edit the `Stage whitelist into ./dist` step in
+`.github/workflows/release.yml`.
+
+## Validation
+
+The workflow enforces two invariants before publishing:
+
+1. `dist/skin-manifest.json` exists and declares `id == "streamline.js"` and
+   a non-empty `version` field.
+2. No file in `dist/` has a Win32-reserved character (`< > : " | ? *`) in its
+   name. Windows `CreateFile` rejects these with `ERROR_INVALID_NAME`, and
+   any such file would crash skin installation on Windows.
+
+A failure on either check stops the release cleanly.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,13 +25,26 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
-The action zips the staged whitelist as `streamline.js-v0.1.0.zip` and
-publishes a GitHub Release with auto-generated notes. Downstream tools
-consume this via:
+The action:
+
+1. Stages the whitelist into `./dist/`
+2. **Rewrites** `dist/skin-manifest.json` to set `version` to the tag name
+   (with the leading `v` stripped — tag `v0.1.0` → version `0.1.0`). This
+   means the git tag is the single source of truth for version and you do
+   not have to bump `skin-manifest.json` manually before tagging.
+3. Zips the staged whitelist as `streamline.js-v0.1.0.zip`
+4. Publishes a GitHub Release with auto-generated notes
+
+Downstream tools consume the release via:
 
 ```
 github_release: <owner>/streamline_project
 ```
+
+Note: the committed `skin-manifest.json` version is only rewritten inside
+the release artifact — the file on disk in `main` is untouched. The `dist`
+branch snapshot (for bleeding-edge dev) keeps the version as committed,
+because tag-based auto-sync only runs on tag builds.
 
 ## Whitelist
 

--- a/skin-manifest.json
+++ b/skin-manifest.json
@@ -1,0 +1,6 @@
+{
+  "id": "streamline.js",
+  "name": "Streamline.js",
+  "description": "Modern, feature-complete WebUI skin for Streamline-Bridge",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
## Summary

Small follow-up to #4 (merged). On tag builds, rewrite the staged `skin-manifest.json` version field from the git tag name (leading `v` stripped) before zipping. The git tag becomes the single source of truth for version — you only have to `git tag vX.Y.Z && git push origin vX.Y.Z`, no manual bump of `skin-manifest.json` needed.

## Why

You asked during the review of #4: "do I need to update `skin-manifest.json` version number when I update?". Strict answer: no — Streamline-Bridge uses the GitHub release tag for update detection, not the manifest field. But Bridge **displays** the manifest `version` in its UI (settings view, skin picker: `v${skin.version}`), so drift between tag and manifest shows stale text to users.

This PR removes the footgun: tag is the source of truth, manifest auto-syncs from it inside the release zip.

## Behavior

- **Tag push (`refs/tags/v*`):** staged manifest version rewritten to the tag name with `v` stripped. `v0.1.0` → `"version": "0.1.0"`, `v0.2.1-rc1` → `"version": "0.2.1-rc1"`.
- **Main push (dist branch):** manifest stays as committed — sync step skipped. Your bleeding-edge `dist` channel keeps reflecting in-repo state.
- **Committed file on disk:** never rewritten. The rewrite only happens inside the `./dist/` staging copy, so `main`'s `skin-manifest.json` stays clean.

## Diff

Adds one step to `.github/workflows/release.yml` right after the staging step:

\`\`\`yaml
- name: Sync skin-manifest.json version from tag
  if: startsWith(github.ref, 'refs/tags/v')
  run: |
    set -euo pipefail
    version="\${GITHUB_REF_NAME#v}"
    jq --arg v "\$version" '.version = \$v' dist/skin-manifest.json > dist/skin-manifest.json.tmp
    mv dist/skin-manifest.json.tmp dist/skin-manifest.json
    echo "Synced manifest version to: \$version"
    cat dist/skin-manifest.json
\`\`\`

Plus a `RELEASE.md` note documenting the behavior.

## Verification

Already verified on `tadelv/streamline_project` (the fork this PR is coming from): https://github.com/tadelv/streamline_project/pull/2. Main push re-published dist branch with committed version unchanged. A future tag test would confirm the sync path, but the step is isolated by the `if: startsWith(github.ref, 'refs/tags/v')` guard so it cannot affect dist-branch behavior.

## Why not one PR

This would have been part of #4 but you merged #4 faster than we could amend it — no complaint, just context. Thanks for the quick turnaround!