### PR TITLE
fix(app): suppress the Bluetooth-off banner while a machine is connected

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:css": "tailwindcss -i ./src/input.css -o ./src/css/app.css --minify",
     "watch:css": "tailwindcss -i ./src/input.css -o ./src/css/app.css --watch",
-    "test": "node --test test/"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build:css": "tailwindcss -i ./src/input.css -o ./src/css/app.css --minify",
-    "watch:css": "tailwindcss -i ./src/input.css -o ./src/css/app.css --watch"
+    "watch:css": "tailwindcss -i ./src/input.css -o ./src/css/app.css --watch",
+    "test": "node --test test/"
   },
   "repository": {
     "type": "git",

--- a/src/modules/app.js
+++ b/src/modules/app.js
@@ -287,6 +287,12 @@ const deviceErrorCopy = {
 function handleDeviceConnectionError(err) {
     // scaleDisconnected is handled silently — the [Reconnect] UI on the main page covers it
     if (err.kind === 'scaleDisconnected') return;
+    // Adapter-level nags (Bluetooth off / permission missing) are meaningless
+    // while a machine is already connected -- connected over USB serial with BT
+    // off is a fully valid state, so don't tell the user to turn BT on. If the
+    // machine is NOT connected the banner still shows, since BT may genuinely be
+    // the missing piece.
+    if ((err.kind === 'adapterOff' || err.kind === 'bluetoothPermissionDenied') && isDe1Connected) return;
     const msg = deviceErrorCopy[err.kind] ?? `${err.message}${err.suggestion ? `\n${err.suggestion}` : ''}`;
     ui.showToast(msg, 5000, 'error');
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,46 @@
+# Streamline test harness
+
+Minimal `node:test` harness — **no dependencies, no DOM, no bundler**. Run it with:
+
+```
+npm test        # = node --test test/
+```
+
+## What belongs here
+
+**Pure functions only.** This skin is a browser SPA; most modules (`api.js`,
+`app.js`, `ui.js`, `chart.js`, …) touch `window` / `document` / `localStorage`
+at import time or immediately after, so they cannot be imported into Node and
+we do not try (no jsdom, ever). What we *do* test is the pure logic: parsing,
+scaling/autoscale math, colour conversions, mode/label resolvers, version and
+manifest invariants.
+
+## The pattern to follow
+
+1. **Put pure helpers in DOM-free modules** (or extract them into one). A
+   module is testable iff importing it touches no browser global. Examples:
+   `src/version.js` and `src/modules/logger.js`. If the helper you want to
+   test lives inside a DOM-coupled module, extract the pure part into its own
+   module and import it from both places — do not import the DOM-coupled
+   module here.
+2. **Name test files `test/<topic>.test.mjs`.** The `.mjs` extension makes
+   Node treat the test itself as an ES module; the sources under `src/` are
+   declared ESM by `src/package.json` (`{"type": "module"}`) so they can be
+   imported directly by relative path. (That marker file is inert for the
+   browser and for the Tailwind build.)
+3. **Use `node:test` + `node:assert/strict`** — see `version.test.mjs` for the
+   shape. No test framework, no new devDependencies.
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SKIN_ID } from '../src/version.js';
+
+test('the skin id is the one reaprime keys the install dir on', () => {
+    assert.equal(SKIN_ID, 'streamline.js');
+});
+```
+
+Good candidates as more pure logic is extracted: chart expanded-view autoscale
+(`niceCeil`, temp-band maths), colour conversions, steam-mode and label
+resolvers.

--- a/test/version.test.mjs
+++ b/test/version.test.mjs
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { APP_VERSION, SKIN_ID } from '../src/version.js';
+
+const manifestPath = fileURLToPath(new URL('../skin-manifest.json', import.meta.url));
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+test('skin id is "streamline.js" everywhere (reaprime keys the install dir on it)', () => {
+    assert.equal(SKIN_ID, 'streamline.js');
+    assert.equal(manifest.id, 'streamline.js');
+});
+
+test('baked APP_VERSION looks like a version string', () => {
+    assert.match(APP_VERSION, /^\d+\.\d+\.\d+/);
+});
+
+test('manifest version looks like a version string', () => {
+    assert.match(manifest.version, /^\d+\.\d+\.\d+/);
+});


### PR DESCRIPTION

Open the skin on a tablet with Bluetooth switched off, while the machine is connected over USB, and
you get told "Bluetooth is off. Turn it on to continue." There is nothing to continue to. The machine
is connected, the shot is ready to pull, and the skin is nagging the user to fix something that is not
broken. Worse, the devices WebSocket re-delivers the same error with a fresh timestamp on every
(re)open, so the toast keeps coming back.

## What changed

Six lines in `handleDeviceConnectionError`. The adapter-level error kinds - `adapterOff` and
`bluetoothPermissionDenied` - are now suppressed when a machine is already connected. If no machine is
connected the banner still shows, because then Bluetooth genuinely may be the missing piece and the
user does need to know.

The gate reads `isDe1Connected`, which is transport-agnostic: it is set from `GET /devices` and does
not care how the machine got there. So this fixes the nag for any wired machine, not just one kind.

There is no boot race. `initMainPageOnce` awaits `initializeDe1Connection()` - which is what sets
`isDe1Connected` - before `connectDeviceWebSocket()` opens the socket that delivers the error, so the
flag is always resolved by the time the first error can arrive.

## How it was verified

`npm test` on this branch: **3 tests, 3 pass, 0 fail.** That is the whole suite at this point; this
change is six lines inside a DOM-coupled handler and adds no pure logic to test.

By hand: reproduced by launching the skin with the tablet's Bluetooth off and the machine live on USB
serial, and confirmed the toast no longer fires while the machine is connected and still fires when it
is not.

**Not verified:** the `bluetoothPermissionDenied` kind specifically. It is gated by the same
condition as `adapterOff` and arrives through the same handler, but the permission-denied path was not
reproduced on the bench - only adapter-off was.

**No Tailwind class changes**, so the CSS artifact is untouched.

## A note on the test harness commit

The first commit adds `"test": "node --test test/"`, a `src/package.json` ESM marker, and
`test/README.md`. It is byte-identical to the same commit in the other PRs in this series, so whichever
lands first, the rest de-duplicate cleanly on rebase. It is carried here only so that `npm test` runs
on this branch; this PR adds no tests of its own.
