### PR TITLE
feat(inputs): theme-aware numpad and time picker (light + dark)

### DIFF
--- a/src/css/numpad-modal.css
+++ b/src/css/numpad-modal.css
@@ -1,31 +1,73 @@
 /* Numpad -- a centred popup card, rendered as a top-layer <dialog> so it stacks
    above any showModal() dialog and is not affected by the app's #scaled-content
-   transform (natural viewport pixels). Palette matches the original Figma dark
-   numpad: #101217 base, #1F2234 keys, #385A92 accent, #DA515E delete. */
+   transform (natural viewport pixels).
+
+   Theme-aware: light values are the defaults (the skin's default theme is
+   data-theme="light"); the [data-theme="dark"] block restores the original Figma
+   dark palette (#101217 base, #1F2234 keys, #385A92 accent, #DA515E delete)
+   byte-for-byte. The navy accent and the red delete glyph read well on both
+   themes, so they are shared. */
+
+.numpad-modal-overlay {
+    --np-card: #ffffff;
+    --np-card-border: rgba(0, 0, 0, 0.10);
+    --np-shadow: rgba(15, 23, 42, 0.28);
+    --np-backdrop: rgba(15, 23, 42, 0.35);
+    --np-text: #2a2e3a;
+    --np-text-strong: #121212;
+    --np-text-soft: #4a5162;
+    --np-text-muted: #6b7280;
+    --np-label: #6b7280;
+    --np-key: #eef0f5;
+    --np-key-hover: #e2e6ee;
+    --np-key-active: #cfd7e6;
+    --np-key-border: #dfe3ec;
+    --np-input-bg: #f6f8fc;
+    --np-cancel-border: rgba(0, 0, 0, 0.18);
+    --np-accent: #385A92;
+}
+
+[data-theme="dark"] .numpad-modal-overlay {
+    --np-card: #101217;
+    --np-card-border: rgba(255, 255, 255, 0.12);
+    --np-shadow: rgba(0, 0, 0, 0.6);
+    --np-backdrop: rgba(0, 0, 0, 0.75);
+    --np-text: #E8E8E8;
+    --np-text-strong: #fff;
+    --np-text-soft: #c7ccdb;
+    --np-text-muted: #8b90a3;
+    --np-label: #959595;
+    --np-key: #1F2234;
+    --np-key-hover: #2b3048;
+    --np-key-active: #3c4671;
+    --np-key-border: #2b3048;
+    --np-input-bg: #0c0e13;
+    --np-cancel-border: rgba(255, 255, 255, 0.18);
+}
 
 .numpad-modal-overlay {
     border: none;
     padding: 0;
     background: transparent;
-    color: #E8E8E8;
+    color: var(--np-text);
     max-width: 96vw;
     max-height: 96vh;
     overflow: visible;
 }
 
 .numpad-modal-overlay::backdrop {
-    background: rgba(0, 0, 0, 0.75);
+    background: var(--np-backdrop);
     backdrop-filter: blur(6px);
 }
 
 .numpad-modal-container {
     width: min(94vw, 460px);
     box-sizing: border-box;
-    background: #101217;
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: var(--np-card);
+    border: 1px solid var(--np-card-border);
     border-radius: 24px;
     padding: 24px;
-    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.6);
+    box-shadow: 0 24px 70px var(--np-shadow);
     font-family: 'Inter', -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
@@ -44,7 +86,7 @@
     font-weight: 800;
     letter-spacing: 0.3px;
     line-height: 1.15;
-    color: #fff;
+    color: var(--np-text-strong);
     overflow: hidden;
     /* Wraps to up to two lines. fitNumpadTitle() (numpad-modal.js) shrinks the
        font ONLY if a line still overflows the available width -- keeping the text
@@ -67,20 +109,20 @@
 }
 .numpad-modal-cancel {
     background: transparent;
-    color: #c7ccdb;
-    border: 1px solid rgba(255, 255, 255, 0.18);
+    color: var(--np-text-soft);
+    border: 1px solid var(--np-cancel-border);
 }
 .numpad-modal-confirm {
-    background: #385A92;
+    background: var(--np-accent);
     color: #fff;
 }
 
 /* value display */
 .numpad-modal-input-box {
     height: 96px;
-    border: 2px solid #385A92;
+    border: 2px solid var(--np-accent);
     border-radius: 16px;
-    background: #0c0e13;
+    background: var(--np-input-bg);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -89,7 +131,7 @@
 .numpad-modal-input-value {
     font-size: 64px;
     font-weight: 800;
-    color: #fff;
+    color: var(--np-text-strong);
     line-height: 1;
     font-variant-numeric: tabular-nums;
     display: inline-flex;
@@ -99,7 +141,7 @@
     display: inline-block;
     width: 3px;
     height: 58px;
-    background: #385A92;
+    background: var(--np-accent);
     margin: 0 1px;
     animation: numpad-blink 1s step-end infinite;
 }
@@ -107,13 +149,13 @@
 .numpad-unit-text {
     font-size: 30px;
     font-weight: 700;
-    color: #8b90a3;
+    color: var(--np-text-muted);
     margin-left: 6px;
 }
 .numpad-modal-input-label {
     text-align: center;
     font-size: 15px;
-    color: #959595;
+    color: var(--np-label);
     margin: 6px 0 16px;
 }
 
@@ -126,7 +168,7 @@
     font-weight: 700;
     letter-spacing: 1px;
     text-transform: uppercase;
-    color: #8b90a3;
+    color: var(--np-text-muted);
     margin-bottom: 8px;
 }
 .numpad-modal-previous-grid {
@@ -136,16 +178,16 @@
 }
 .numpad-modal-previous-btn {
     height: 46px;
-    background: #1F2234;
-    border: 1px solid #2b3048;
+    background: var(--np-key);
+    border: 1px solid var(--np-key-border);
     border-radius: 12px;
-    color: #c7ccdb;
+    color: var(--np-text-soft);
     font-size: 20px;
     font-weight: 700;
     cursor: pointer;
 }
 .numpad-modal-previous-btn:active {
-    background: #2b3048;
+    background: var(--np-key-hover);
 }
 
 /* keypad */
@@ -156,10 +198,10 @@
 }
 .numpad-modal-numpad-btn {
     height: 66px;
-    background: #1F2234;
+    background: var(--np-key);
     border: none;
     border-radius: 14px;
-    color: #fff;
+    color: var(--np-text-strong);
     font-size: 32px;
     font-weight: 800;
     cursor: pointer;
@@ -167,8 +209,8 @@
     align-items: center;
     justify-content: center;
 }
-.numpad-modal-numpad-btn:hover { background: #2b3048; }
-.numpad-modal-numpad-btn:active { background: #3c4671; }
+.numpad-modal-numpad-btn:hover { background: var(--np-key-hover); }
+.numpad-modal-numpad-btn:active { background: var(--np-key-active); }
 .numpad-modal-numpad-btn.numpad-decimal { font-size: 34px; }
 .numpad-modal-numpad-btn.numpad-delete .delete-icon-small {
     width: 34px;

--- a/src/css/time-picker-modal.css
+++ b/src/css/time-picker-modal.css
@@ -1,31 +1,68 @@
 /* Clock-face time picker (see src/modules/time-picker-modal.js).
    Rendered as a native <dialog> in the top layer, so it is NOT affected by the
-   app's #scaled-content transform -- sizes are real viewport pixels. Palette is
-   matched to the numpad card: #101217 base, #1F2234 boxes, #385A92 accent. */
+   app's #scaled-content transform -- sizes are real viewport pixels.
+
+   Theme-aware, matched to the numpad card: light values are the defaults (the
+   skin's default theme is data-theme="light"); the [data-theme="dark"] block
+   restores the original dark palette (#101217 base, #1F2234 boxes, #385A92
+   accent) byte-for-byte. The navy accent is shared by both themes; the selected
+   number stays white because it sits on the navy knob in either theme. */
+
+.tpm-dialog {
+    --tpm-card: #ffffff;
+    --tpm-card-border: rgba(0, 0, 0, 0.10);
+    --tpm-shadow: rgba(15, 23, 42, 0.28);
+    --tpm-backdrop: rgba(15, 23, 42, 0.35);
+    --tpm-text: #2a2e3a;
+    --tpm-text-strong: #121212;
+    --tpm-text-soft: #4a5162;
+    --tpm-text-muted: #6b7280;
+    --tpm-key: #eef0f5;
+    --tpm-seg-active-bg: rgba(56, 90, 146, 0.12);
+    --tpm-face: rgba(56, 90, 146, 0.10);
+    --tpm-cancel-border: rgba(0, 0, 0, 0.18);
+    --tpm-accent: #385A92;
+    --tpm-accent-soft: #5f8ad6;
+}
+
+[data-theme="dark"] .tpm-dialog {
+    --tpm-card: #101217;
+    --tpm-card-border: rgba(255, 255, 255, 0.12);
+    --tpm-shadow: rgba(0, 0, 0, 0.6);
+    --tpm-backdrop: rgba(0, 0, 0, 0.75);
+    --tpm-text: #E8E8E8;
+    --tpm-text-strong: #fff;
+    --tpm-text-soft: #c7ccdb;
+    --tpm-text-muted: #8b90a3;
+    --tpm-key: #1F2234;
+    --tpm-seg-active-bg: rgba(56, 90, 146, 0.22);
+    --tpm-face: rgba(120, 140, 180, 0.12);
+    --tpm-cancel-border: rgba(255, 255, 255, 0.18);
+}
 
 .tpm-dialog {
     border: none;
     padding: 0;
     background: transparent;
-    color: #E8E8E8;
+    color: var(--tpm-text);
     max-width: 96vw;
     max-height: 96vh;
     overflow: visible;
 }
 
 .tpm-dialog::backdrop {
-    background: rgba(0, 0, 0, 0.75);
+    background: var(--tpm-backdrop);
     backdrop-filter: blur(6px);
 }
 
 .tpm-card {
     width: min(94vw, 360px);
     box-sizing: border-box;
-    background: #101217;
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: var(--tpm-card);
+    border: 1px solid var(--tpm-card-border);
     border-radius: 24px;
     padding: 24px;
-    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.6);
+    box-shadow: 0 24px 70px var(--tpm-shadow);
     font-family: 'Inter', -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
@@ -44,7 +81,7 @@
     font-weight: 800;
     letter-spacing: 0.3px;
     text-transform: uppercase;
-    color: #fff;
+    color: var(--tpm-text-strong);
 }
 
 /* Display: the whole HH : MM + AM/PM group is centred as one unit. */
@@ -61,8 +98,8 @@
     height: 68px;
     border: none;
     border-radius: 12px;
-    background: #1F2234;
-    color: #E8E8E8;
+    background: var(--tpm-key);
+    color: var(--tpm-text);
     font-size: 42px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
@@ -70,15 +107,15 @@
 }
 
 .tpm-seg-active {
-    background: rgba(56, 90, 146, 0.22);
-    color: #fff;
-    box-shadow: inset 0 0 0 2px #5f8ad6;
+    background: var(--tpm-seg-active-bg);
+    color: var(--tpm-text-strong);
+    box-shadow: inset 0 0 0 2px var(--tpm-accent-soft);
 }
 
 .tpm-colon {
     font-size: 38px;
     font-weight: 700;
-    color: #8b90a3;
+    color: var(--tpm-text-muted);
 }
 
 .tpm-ampm {
@@ -86,7 +123,7 @@
     flex-direction: column;
     height: 68px;
     margin-left: 4px;
-    border: 1px solid #385A92;
+    border: 1px solid var(--tpm-accent);
     border-radius: 11px;
     overflow: hidden;
 }
@@ -96,7 +133,7 @@
     width: 54px;
     border: none;
     background: transparent;
-    color: #c7ccdb;
+    color: var(--tpm-text-soft);
     font-size: 15px;
     font-weight: 700;
     opacity: 0.65;
@@ -104,11 +141,11 @@
 }
 
 .tpm-ampm-btn + .tpm-ampm-btn {
-    border-top: 1px solid #385A92;
+    border-top: 1px solid var(--tpm-accent);
 }
 
 .tpm-ampm-on {
-    background: #385A92;
+    background: var(--tpm-accent);
     color: #fff;
     opacity: 1;
 }
@@ -126,26 +163,26 @@
 }
 
 .tpm-face {
-    fill: rgba(120, 140, 180, 0.12);
+    fill: var(--tpm-face);
 }
 
 .tpm-hand {
-    stroke: #5f8ad6;
+    stroke: var(--tpm-accent-soft);
     stroke-width: 2.5;
 }
 
 .tpm-knob {
-    fill: #385A92;
+    fill: var(--tpm-accent);
 }
 
 .tpm-hub {
-    fill: #5f8ad6;
+    fill: var(--tpm-accent-soft);
 }
 
 .tpm-num {
     font-size: 17px;
     font-weight: 700;
-    fill: #E8E8E8;
+    fill: var(--tpm-text);
     text-anchor: middle;
     dominant-baseline: central;
     cursor: pointer;
@@ -179,11 +216,11 @@
 
 .tpm-cancel {
     background: transparent;
-    color: #c7ccdb;
-    border: 1px solid rgba(255, 255, 255, 0.18);
+    color: var(--tpm-text-soft);
+    border: 1px solid var(--tpm-cancel-border);
 }
 
 .tpm-ok {
-    background: #385A92;
+    background: var(--tpm-accent);
     color: #fff;
 }


### PR DESCRIPTION
Follow-up to #21. The new numpad card and clock time picker were hardcoded to the Figma dark palette, so on the default light theme they rendered as dark cards over a light page.

## What changed
- Both `numpad-modal.css` and `time-picker-modal.css` now use component-scoped CSS variables.
- **Light values are the defaults** (matching the skin's `data-theme="light"` default): white card, light-grey keys, dark text.
- **`[data-theme="dark"]` restores the original dark palette exactly** (#101217 base, #1F2234 keys, #385A92 accent) — dark-mode users see zero change.
- The navy accent (#385A92) and red delete glyph (#DA515E) are shared by both themes.
- CSS-only: no JS or markup changes, no Tailwind rebuild needed.

## Verified
Opened both dialogs in a browser against the live app and screenshotted both themes: light renders as a white card consistent with the rest of the light UI; dark is pixel-identical to the pre-change palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)