### PR TITLE
Remove back button text, translate expanded-chart legends

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,6 @@
             <div style="height:96px; flex:0 0 96px; display:flex; align-items:center; justify-content:space-between; padding:0 44px; border-bottom:1px solid var(--border-color);">
                 <button id="expanded-chart-back" aria-label="Back to main screen" style="display:flex; align-items:center; gap:16px; background:transparent; border:none; cursor:pointer; padding:10px 14px; margin-left:-14px; border-radius:14px;">
                     <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="var(--mimoja-blue)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 18l-6-6 6-6"/></svg>
-                    <span style="color:var(--mimoja-blue); font-size:30px; font-weight:600; font-family:'Inter',sans-serif;" data-i18n-key="Back">Back</span>
                 </button>
                 <div style="color:var(--text-primary); font-size:30px; font-weight:600; font-family:'Inter',sans-serif;">Live Charts</div>
                 <div style="width:140px;" aria-hidden="true"></div>

--- a/src/modules/chart.js
+++ b/src/modules/chart.js
@@ -618,23 +618,23 @@ function expandedLayout(theme, yRange, isTemp) {
 function expandedTopTraces() {
     const s = expandedSeries;
     return [
-        { x: s.pressure.x, y: s.pressure.y, name: 'Pressure (bar)', mode: 'lines', line: { color: '#17c29a', width: 3 }, hoverinfo: 'skip' },
-        { x: s.flow.x, y: s.flow.y, name: 'Flow (ml/s)', mode: 'lines', line: { color: '#0358cf', width: 3 }, hoverinfo: 'skip' },
-        { x: s.gflow.x, y: s.gflow.y, name: 'GFlow (g/s)', mode: 'lines', line: { color: '#C7A58D', width: 3 }, hoverinfo: 'skip' },
-        { x: s.targetPressure.x, y: s.targetPressure.y, name: 'Target Pressure', mode: 'lines', line: { color: '#8fd3bf', dash: 'dot', width: 2 }, hoverinfo: 'skip' },
-        { x: s.targetFlow.x, y: s.targetFlow.y, name: 'Target Flow', mode: 'lines', line: { color: '#7fa8ec', dash: 'dot', width: 2 }, hoverinfo: 'skip' },
+        { x: s.pressure.x, y: s.pressure.y, name: getTranslation('Pressure (bar)'), mode: 'lines', line: { color: '#17c29a', width: 3 }, hoverinfo: 'skip' },
+        { x: s.flow.x, y: s.flow.y, name: getTranslation('Flow (ml/s)'), mode: 'lines', line: { color: '#0358cf', width: 3 }, hoverinfo: 'skip' },
+        { x: s.gflow.x, y: s.gflow.y, name: getTranslation('GFlow (g/s)'), mode: 'lines', line: { color: '#C7A58D', width: 3 }, hoverinfo: 'skip' },
+        { x: s.targetPressure.x, y: s.targetPressure.y, name: getTranslation('Target Pressure'), mode: 'lines', line: { color: '#8fd3bf', dash: 'dot', width: 2 }, hoverinfo: 'skip' },
+        { x: s.targetFlow.x, y: s.targetFlow.y, name: getTranslation('Target Flow'), mode: 'lines', line: { color: '#7fa8ec', dash: 'dot', width: 2 }, hoverinfo: 'skip' },
     ];
 }
 
 function expandedTempTraces() {
     const s = expandedSeries;
     const traces = [
-        { x: s.groupTemp.x, y: s.groupTemp.y, name: 'Group °C', mode: 'lines', line: { color: '#ff97a1', width: 3 }, hoverinfo: 'skip' },
+        { x: s.groupTemp.x, y: s.groupTemp.y, name: getTranslation('Group °C'), mode: 'lines', line: { color: '#ff97a1', width: 3 }, hoverinfo: 'skip' },
         // Amber, CVD-validated against the group pink (worst ΔE 14.7, ≥12 req);
         // solid 3px = "actual" convention (targets are the dotted ones).
-        { x: s.mixTemp.x, y: s.mixTemp.y, name: 'Mix °C', mode: 'lines', line: { color: '#d9822b', width: 3 }, hoverinfo: 'skip' },
+        { x: s.mixTemp.x, y: s.mixTemp.y, name: getTranslation('Mix °C'), mode: 'lines', line: { color: '#d9822b', width: 3 }, hoverinfo: 'skip' },
         // Two targets now, so "Target °C" would be ambiguous — say which is which.
-        { x: s.targetTemp.x, y: s.targetTemp.y, name: 'Group Target °C', mode: 'lines', line: { color: '#f0b8bd', dash: 'dot', width: 2 }, hoverinfo: 'skip' },
+        { x: s.targetTemp.x, y: s.targetTemp.y, name: getTranslation('Group Target °C'), mode: 'lines', line: { color: '#f0b8bd', dash: 'dot', width: 2 }, hoverinfo: 'skip' },
     ];
     // Mix target: the amber lightened toward white the same way the group target
     // is a lightened group pink, thin + dashed = the "target, not measurement"
@@ -643,7 +643,7 @@ function expandedTempTraces() {
     // trace entirely rather than draw an empty/zero line.
     if (s.targetMixTemp.y.length) {
         traces.push({
-            x: s.targetMixTemp.x, y: s.targetMixTemp.y, name: 'Mix Target °C', mode: 'lines',
+            x: s.targetMixTemp.x, y: s.targetMixTemp.y, name: getTranslation('Mix Target °C'), mode: 'lines',
             line: { color: '#e8b480', dash: 'dash', width: 2 }, hoverinfo: 'skip',
         });
     }


### PR DESCRIPTION
## Summary
- Removed the "Back" text next to `#expanded-chart-back`, icon-only now (aria-label kept).
- Expanded live-chart legend names (Pressure, Flow, GFlow, Target Pressure, Target Flow, Group °C, Mix °C, Group Target °C, Mix Target °C) now route through `getTranslation()`.

## Test plan
- [ ] Open expanded chart view, confirm back button is icon-only.
- [ ] Switch language, confirm legend labels translate where a CSV key exists.