### PR TITLE
Use single translation key for espresso-heating status

### DIFF
--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -2248,11 +2248,8 @@ export function updateMachineStatus(data) {
         logger.debug('DEBUG: Out of water state - Set machine status with red styling');
     } else if (isEspressoPreparingForShot) {
         logger.debug('Entering isEspressoPreparingForShot condition');
-        const espressoonlytext = getTranslation('Espresso');
-        const espressoheatingtext = getTranslation('Heating'); 
-        const pleasetext = getTranslation('please');
-        const waittext = getTranslation('wait');
-        machineStatusEl.innerHTML = `<span class="text-[var(--status-red-color)]">${espressoonlytext} ${espressoheatingtext} : </span><span class="text-[var(--status-clickable-color)]">${pleasetext} ${waittext}</span>`;
+        const espressoHeatingWaitText = getTranslation('Espresso Heating : Please wait');
+        machineStatusEl.innerHTML = `<span class="text-[var(--status-red-color)]">${espressoHeatingWaitText}</span>`;
     } else if (isHeatingWithTimeRemaining) {
         // Split the status string to apply different colors to "Heating" and "Xs remaining"
         const parts = status.split(': ');


### PR DESCRIPTION
## Summary
- Machine-status "Espresso Heating / please wait" text now uses a single "Espresso Heating : Please wait" translation key instead of composing 4 separate keys.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>