### PR TITLE
Bump version to 0.1.80

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamline_project",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "description": "A modern web UI skin for the Decent Espresso DE1, built on top of [Streamline-Bridge (reaprime)](https://github.com/tadelv/reaprime). This is a full rewrite of the original TCL-based Streamline skin into a browser-native web application — no framework, no bundler, just HTML/CSS/JS served as static files.",
   "main": "index.js",
   "scripts": {

--- a/skin-manifest.json
+++ b/skin-manifest.json
@@ -2,5 +2,5 @@
   "id": "streamline.js",
   "name": "Streamline.js",
   "description": "Modern, feature-complete WebUI skin for Streamline-Bridge",
-  "version": "0.1.79"
+  "version": "0.1.80"
 }

--- a/src/version.js
+++ b/src/version.js
@@ -3,7 +3,7 @@
 // skin in the background — a mismatch means "reload to apply".
 //
 // BUMP THIS when cutting a release, in the same step as pushing the git tag.
-export const APP_VERSION = '0.1.79';
+export const APP_VERSION = '0.1.80';
 
 // Our skin id as registered with Streamline-Bridge (matches manifest.json / reaMetadata.skinId).
 export const SKIN_ID = 'streamline.js';


### PR DESCRIPTION
## Summary
- Bump version across the three files it lives in: src/version.js, package.json, skin-manifest.json
- Follow-up to #28 (pump ramp transition rendering fix), preparing to cut release v0.1.80

🤖 Generated with [Claude Code](https://claude.com/claude-code)