### PR TITLE
fix(display): restore brightness on BLE drop, stop flooding the host log

### DIFF
--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -3,6 +3,7 @@ import { logger ,setDebug} from './logger.js';
 import { createSocketSlot } from './socket-slot.js';
 import { openDB, getSetting, setSetting } from './idb.js';
 import { buildCalibrateBody, calResponseHasBody } from './loadcell-cal.js';
+import { deriveDisplayAction } from './screensaver-policy.js';
 
 export let reaHostname = localStorage.getItem('reaHostname') || window.location.hostname;
 export const REA_PORT = 8080;
@@ -208,9 +209,8 @@ export async function calibrateScale(command, grams) {
 
 export function connectWebSocket(onData, onReconnect) {
     reconnectingWebSocket = snapshotSocketSlot.replace(() => new ReconnectingWebSocket(`${WS_PROTOCOL}//${reaHostname}:${REA_PORT}/ws/v1/machine/snapshot`, [], {
-        debug: true,
         reconnectInterval: 3000,
-    })); // Enable debug logging
+    }));
 
     reconnectingWebSocket.onopen = () => {
         logger.info('WebSocket (re)connected.');
@@ -234,17 +234,15 @@ export function connectWebSocket(onData, onReconnect) {
             currentMachineState = stateValue;
             // logger.info('Current state after assignment:', currentMachineState);
             
-            if (previousMachineState !== currentMachineState) {
-                logger.info('State changed! Checking conditions...');
-                if (currentMachineState === MachineState.SLEEPING) {
-                    logger.info('Machine state changed to SLEEPING. Dimming display.');
-                    dimDisplay();
-                } else if (currentMachineState === MachineState.IDLE) {
-                    logger.info('Machine state changed to IDLE. Restoring display.');
-                    restoreDisplay();
-                }
-            } else {
-                // logger.info('State did not change, skipping display adjustment.');
+            // Brightness follows the machine's confirmed state. See
+            // deriveDisplayAction() for why 'error' has to release the dim.
+            const displayAction = deriveDisplayAction(previousMachineState, currentMachineState);
+            if (displayAction === 'dim') {
+                logger.info(`Machine state changed to ${currentMachineState}. Dimming display.`);
+                dimDisplay();
+            } else if (displayAction === 'restore') {
+                logger.info(`Machine state changed to ${currentMachineState}. Restoring display.`);
+                restoreDisplay();
             }
             
             onData(data);
@@ -278,7 +276,6 @@ export function connectScaleWebSocket(onData, onReconnect, onDisconnect) {
     }
 
     scaleWebSocket = new ReconnectingWebSocket(`${WS_PROTOCOL}//${reaHostname}:${REA_PORT}/ws/v1/scale/snapshot`, [], {
-        debug: true,
         reconnectInterval: 3000,
     });
 
@@ -322,7 +319,6 @@ export function connectScaleWebSocket(onData, onReconnect, onDisconnect) {
 
 export function connectShotSettingsWebSocket(onData) {
     const shotSettingsWebSocket = shotSettingsSocketSlot.replace(() => new ReconnectingWebSocket(`${WS_PROTOCOL}//${reaHostname}:${REA_PORT}/ws/v1/machine/shotSettings`, [], {
-        debug: true,
         reconnectInterval: 3000,
     }));
 
@@ -354,7 +350,6 @@ export function connectShotSettingsWebSocket(onData) {
 // socket is not gated on a connected machine — attach once and keep it open.
 export function connectShotStateWebSocket(onData) {
     const shotStateWebSocket = new ReconnectingWebSocket(`${WS_PROTOCOL}//${reaHostname}:${REA_PORT}/ws/v1/machine/shotState`, [], {
-        debug: true,
         reconnectInterval: 3000,
     });
 
@@ -381,7 +376,6 @@ export function connectShotStateWebSocket(onData) {
 
 export function connectTimeToReadyWebSocket(onData) {
     const timeToReadyWebSocket = new ReconnectingWebSocket(`${WS_PROTOCOL}//${reaHostname}:${REA_PORT}/ws/v1/plugins/time-to-ready.reaplugin/timeToReady`, [], {
-        debug: true,
         reconnectInterval: 3000,
     });
 
@@ -472,7 +466,6 @@ export function connectDeviceWebSocket(onData, onReconnect, onDisconnect, onErro
     }
 
     deviceWebSocket = new ReconnectingWebSocket(`${WS_PROTOCOL}//${reaHostname}:${REA_PORT}/ws/v1/devices`, [], {
-        debug: true,
         reconnectInterval: 3000,
     });
 
@@ -586,7 +579,6 @@ export function connectDisplayWebSocket(onData) {
     }
 
     displayWebSocket = new ReconnectingWebSocket(`${WS_PROTOCOL}//${reaHostname}:${REA_PORT}/ws/v1/display`, [], {
-        debug: true,
         reconnectInterval: 3000,
     });
 
@@ -685,7 +677,6 @@ export function connectUpdateWebSocket(onData) {
     }
 
     updateWebSocket = new ReconnectingWebSocket(`${WS_PROTOCOL}//${reaHostname}:${REA_PORT}/ws/v1/update`, [], {
-        debug: true,
         reconnectInterval: 3000,
     });
 

--- a/src/modules/app.js
+++ b/src/modules/app.js
@@ -659,7 +659,12 @@ function handleData(data) {
 
     // Check if the machine is in an error state that indicates disconnection
     if (state === MachineState.ERROR) {
-        logger.warn('DE1 machine in error state, likely disconnected.');
+        // Log the edge only. Snapshots keep arriving at ~10 Hz while the machine is
+        // gone, and logging every one of them filled the host's WebView console log
+        // (1 MB every ~2 min) for as long as the DE1 stayed disconnected.
+        if (previousState.state !== MachineState.ERROR) {
+            logger.warn('DE1 machine in error state, likely disconnected.');
+        }
         isDe1Connected = false;
         ui.updateMachineStatus({ status: "Disconnected" });
     }
@@ -864,7 +869,11 @@ function handleScaleData(data) {
         if (!isScaleConnected) {
             renderScaleDisconnectedText();
         }
-        logger.warn('Scale message received without weight data.');
+        // debug, not warn: weightless frames repeat for as long as the scale is
+        // away (and some scales send battery-only frames while connected), so one
+        // warn each flooded the host's WebView console log. The connect and
+        // disconnect edges are already logged either side of this.
+        logger.debug('Scale message received without weight data.');
     }
 }
 

--- a/src/modules/screensaver-policy.js
+++ b/src/modules/screensaver-policy.js
@@ -115,3 +115,25 @@ export function deriveSleepButtonAction({ machineState, screensaverActive = fals
     // screensaver when the machine confirms it is sleeping.
     return { command: 'sleeping', hideScreensaver: false };
 }
+
+/**
+ * What the panel brightness should do on a machine state TRANSITION.
+ *
+ * 'error' means the DE1 fell off BLE. It has to release the dim, because the only
+ * other thing that does is an 'idle' frame and a machine that is gone never sends
+ * one: a drop while the machine was asleep used to leave the tablet dark for the
+ * rest of the session, recoverable only by the settings slider the user could not
+ * see (reaprime#519). If it comes back still asleep, the sleeping transition dims
+ * it again.
+ *
+ * Transition-only by design — the snapshot feed repeats the same state at ~10 Hz,
+ * and re-dimming on every frame would clobber a brightness the user just chose.
+ *
+ * @returns {'dim'|'restore'|'none'}
+ */
+export function deriveDisplayAction(previousState, currentState) {
+    if (previousState === currentState) return 'none';
+    if (isMachineAsleep(currentState)) return 'dim';
+    if (currentState === 'idle' || currentState === 'error') return 'restore';
+    return 'none';
+}

--- a/src/modules/waterTank.js
+++ b/src/modules/waterTank.js
@@ -92,7 +92,6 @@ export function initWaterTankSocket() {
     tankVolElementRef = tankVolElement;
 
     const socket = waterLevelSocketSlot.replace(() => new ReconnectingWebSocket(`${WS_PROTOCOL}//${window.location.hostname}:${REA_PORT}/ws/v1/machine/waterLevels`, [], {
-        debug: true,
         reconnectInterval: 3000,
     }));
 

--- a/test/screensaver-policy.test.mjs
+++ b/test/screensaver-policy.test.mjs
@@ -15,6 +15,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+    deriveDisplayAction,
     deriveScreensaverAction,
     deriveSleepButtonAction,
     isMachineAsleep,
@@ -216,4 +217,46 @@ test('sleep button derivation is pure — repeated calls give the same answer', 
     const input = { machineState: 'idle', screensaverActive: false };
     assert.deepEqual(deriveSleepButtonAction(input), deriveSleepButtonAction(input));
     assert.deepEqual(deriveSleepButtonAction(input), { command: 'sleeping', hideScreensaver: false });
+});
+
+// --- deriveDisplayAction: a dim must always have something that undoes it -------
+//
+// reaprime#519: the DE1 dropped off BLE while asleep. The dim was applied on the
+// 'sleeping' transition and only an 'idle' transition released it — which a machine
+// that is no longer there never sends. The tablet stayed dark for the rest of the
+// session, with the settings brightness slider (invisible on a dark panel) the only
+// way back.
+
+test('a machine that drops off BLE while asleep releases the dim', () => {
+    assert.equal(deriveDisplayAction('idle', 'sleeping'), 'dim');
+    assert.equal(deriveDisplayAction('sleeping', 'error'), 'restore');
+});
+
+test('every state that can follow a dim eventually restores — no dead end', () => {
+    // Whatever the machine does next after we dimmed it, there must be a path back
+    // to a lit panel. The only states that legitimately follow 'sleeping' are a wake
+    // ('idle') and a disconnect ('error'); both restore.
+    for (const next of ['idle', 'error']) {
+        assert.equal(deriveDisplayAction('sleeping', next), 'restore', `${next} must undo the dim`);
+    }
+});
+
+test('the display action is transition-only — a repeated state does nothing', () => {
+    // The snapshot feed repeats the same state at ~10 Hz. Acting on every frame would
+    // re-dim over a brightness the user just picked on the settings slider.
+    for (const state of ['sleeping', 'idle', 'error', 'espresso']) {
+        assert.equal(deriveDisplayAction(state, state), 'none');
+    }
+});
+
+test('states that are neither sleep nor a wake nor a drop leave brightness alone', () => {
+    for (const next of ['espresso', 'steam', 'hotWater', 'heating', 'flush', 'booting']) {
+        assert.equal(deriveDisplayAction('idle', next), 'none');
+    }
+});
+
+test('the first frame after boot dims if the machine is already asleep', () => {
+    // previousMachineState starts undefined; an already-sleeping machine must still dim.
+    assert.equal(deriveDisplayAction(undefined, 'sleeping'), 'dim');
+    assert.equal(deriveDisplayAction(undefined, 'idle'), 'restore');
 });


### PR DESCRIPTION
Both skin-side bugs found while reviewing [reaprime#519](https://github.com/tadelv/reaprime/issues/519) ("App quit Bluetooth drop screen dimmed yet again").

## 1. A dim with nothing to undo it

Brightness was dimmed on the transition to `sleeping` and restored only on the transition to `idle`. When the DE1 fell off BLE while asleep, no `idle` frame ever arrived — so the panel stayed dark for the rest of the session, recoverable only via the settings brightness slider, which is unreadable on a dark panel.

The transition rule now lives in `screensaver-policy.js` as the pure `deriveDisplayAction()`, alongside the other "what the machine's state means for the screen" derivations, so `node --test` covers it. `error` releases the dim; if the machine returns still asleep, the `sleeping` transition dims it again.

## 2. Console log flood

Every `ReconnectingWebSocket` was constructed with `debug: true`, which logs the full JSON payload of every frame (`reconnecting-websocket.js:295`). With the snapshot feed at ~10 Hz that alone filled reaprime's WebView console log — 0.5 MB every ~2 min, 158 truncations over one 9-hour session in the issue's logs. Removed from all 9 sockets (`api.js` ×8, `waterTank.js` ×1); the option defaults to `false`.

Two per-frame log lines in `app.js` added to it:
- the "machine in error state" warn fired on every snapshot for as long as the DE1 was away — now logs the edge only
- the weightless-scale-frame warn fired on every scale frame — dropped to `logger.debug`, since it repeats for as long as the scale is away and some scales send battery-only frames while connected

## Not in scope

The ~20 s BLE scan loop in the issue's logs (15 s scan + 5 s pause, forever, because a remembered scale never appears) is reaprime's own `ConnectionManager`, not this skin — the skin only scans on user action.

## Verification

`node --test test/*.mjs` → 207 pass (5 new, covering the dim/restore transitions, the no-dead-end invariant, and transition-only behavior). No new Tailwind classes, so no CSS rebuild. Version deliberately not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)