### PR TITLE
feat(settings): support secure plugin settings isSet API (decaid #588)

### DIFF
--- a/rest_v1.yml
+++ b/rest_v1.yml
@@ -2465,36 +2465,50 @@ paths:
     get:
       tags: [Plugins]
       summary: Fetch settings for specific plugin
+      description: Secure settings are represented by an isSet state object and never returned as plaintext.
       parameters:
         - name: id
           in: path
+          required: true
           description: the plugin id
+          schema:
+            type: string
       responses:
         "200":
+          description: Current settings with secure values redacted
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/PluginSettings'
 
     post:
       tags: [Plugins]
       summary: Save settings for specific plugin
+      description: >
+        Applies a settings patch. Omitted fields preserve the existing value;
+        a null value clears the setting. For secure fields, an isSet state
+        object preserves the stored credential; null clears it. The response
+        is always redacted and never echoes a submitted credential.
       parameters:
         - name: id
           in: path
+          required: true
           description: the plugin id
+          schema:
+            type: string
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/PluginSettings'
       responses:
         "200":
+          description: Updated settings with secure values redacted
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/PluginSettings'
 
   /api/v1/plugins/{id}/enable:
     post:
@@ -5887,6 +5901,19 @@ components:
         autoLoad:
           type: boolean
           description: Whether the plugin is set to auto-load on startup
+
+    PluginSettings:
+      type: object
+      description: >
+        Plugin setting values. Fields marked secure in the manifest are returned
+        as objects containing only an isSet boolean instead of their stored
+        values. In POST bodies, omitted fields preserve the existing value and
+        a null value clears the setting.
+      additionalProperties: true
+      example:
+        Username: user@example.com
+        Password:
+          isSet: true
 
     ProfileRecord:
       type: object

--- a/src/modules/profile_selector.js
+++ b/src/modules/profile_selector.js
@@ -13,7 +13,7 @@ let cachedVisualizerCredentials = null;
 
 /**
  * Check if Visualizer credentials are configured
- * @returns {Promise<{configured: boolean, username: string|null, password: string|null}>}
+ * @returns {Promise<{configured: boolean, username: string|null, passwordSet: boolean}>}
  */
 async function checkVisualizerCredentials() {
     if (cachedVisualizerCredentials) {
@@ -24,19 +24,23 @@ async function checkVisualizerCredentials() {
         const settings = await getPluginSettings('visualizer.reaplugin');
         const enabled = settings?.Enabled !== false; // Default to enabled
         const username = settings?.Username;
+        // Secure settings come back as { isSet } state, never plaintext (decaid #588).
         const password = settings?.Password;
-        
+        const passwordSet = password == null ? false
+            : typeof password === 'object' ? password.isSet === true
+            : !!password; // legacy cleartext from older decaid
+
         cachedVisualizerCredentials = {
-            configured: enabled && !!(username && password),
+            configured: enabled && !!(username && passwordSet),
             enabled: enabled,
             username: username || null,
-            password: password || null
+            passwordSet
         };
         
         return cachedVisualizerCredentials;
     } catch (error) {
         logger.error('Error checking Visualizer credentials:', error);
-        return { configured: false, enabled: true, username: null, password: null };
+        return { configured: false, enabled: true, username: null, passwordSet: false };
     }
 }
 

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -4977,6 +4977,10 @@ function setupDye2SettingsListeners() {
     });
 }
 
+// Whether the visualizer plugin currently has a stored (secure) password.
+// PR #588: secure values are returned as { isSet } state, never plaintext.
+let visualizerPasswordIsSet = false;
+
 // Function to set up event listeners for the Visualizer settings
 function setupVisualizerEventListeners() {
     const saveButton = document.getElementById('save-visualizer-credentials');
@@ -5064,52 +5068,62 @@ function setupVisualizerEventListeners() {
         const username = usernameInput.value.trim();
         const password = passwordInput.value; // Don't trim password as spaces might be valid
 
-        if (!username || !password) {
-            ui.showToast('Please enter both username and password', 1500, 'error');
+        if (!username) {
+            ui.showToast('Please enter your Visualizer username', 1500, 'error');
             return;
         }
 
-        try {
-            // Import verifyVisualizerCredentials from api.js
-            const { verifyVisualizerCredentials } = await import('../modules/api.js');
-
-            const isValid = await verifyVisualizerCredentials(username, password);
-
-            if (!isValid) {
-                ui.showToast('Visualizer log-in failed, check credentials', 900, 'error');
-                return; // Stop here if credentials are bad
-            }
-
-            ui.showToast('Visualizer log-in success', 900, 'success');
-
-            // If credentials are valid, proceed to save to plugin
-            const autoUpload = autoUploadCheckbox.checked;
-            const minDuration = parseInt(minDurationInput.value, 10) || 5;
-
-            // 1. Save UI-only settings to localStorage
-            localStorage.setItem('visualizerAutoUpload', autoUpload.toString());
-
-            // 2. Prepare and save plugin settings - use correct field names expected by visualizer plugin manifest
-            const { setPluginSettings } = await import('../modules/api.js');
-            const pluginId = 'visualizer.reaplugin';
-
-            const settingsPayload = {
-                Username: username,
-                Password: password,
-                AutoUpload: autoUpload,
-                LengthThreshold: minDuration
-            };
-
+        // Settings POST is a patch (decaid #588): a typed password sets the
+        // credential, an empty field preserves the stored one via the isSet
+        // marker, an empty field with nothing stored leaves it unset.
+        let passwordPayload;
+        if (password) {
             try {
-                await setPluginSettings(pluginId, settingsPayload);
-                ui.showToast('Visualizer settings saved successfully', 3000, 'success');
+                // Import verifyVisualizerCredentials from api.js
+                const { verifyVisualizerCredentials } = await import('../modules/api.js');
+
+                const isValid = await verifyVisualizerCredentials(username, password);
+
+                if (!isValid) {
+                    ui.showToast('Visualizer log-in failed, check credentials', 900, 'error');
+                    return; // Stop here if credentials are bad
+                }
+
+                ui.showToast('Visualizer log-in success', 900, 'success');
             } catch (error) {
-                console.error('Failed to save visualizer plugin settings:', error);
-                ui.showToast(`Failed to save to decent.app plugin: ${error.message}`, 3000, 'error');
+                console.error('Error during credential validation:', error);
+                ui.showToast(`Error validating credentials: ${error.message}`, 3000, 'error');
+                return;
             }
+            passwordPayload = password;
+        } else {
+            passwordPayload = { isSet: visualizerPasswordIsSet }; // preserve current state
+        }
+
+        // Proceed to save to plugin
+        const autoUpload = autoUploadCheckbox.checked;
+        const minDuration = parseInt(minDurationInput.value, 10) || 5;
+
+        // 1. Save UI-only settings to localStorage
+        localStorage.setItem('visualizerAutoUpload', autoUpload.toString());
+
+        // 2. Prepare and save plugin settings - use correct field names expected by visualizer plugin manifest
+        const { setPluginSettings } = await import('../modules/api.js');
+        const pluginId = 'visualizer.reaplugin';
+
+        const settingsPayload = {
+            Username: username,
+            Password: passwordPayload,
+            AutoUpload: autoUpload,
+            LengthThreshold: minDuration
+        };
+
+        try {
+            await setPluginSettings(pluginId, settingsPayload);
+            ui.showToast('Visualizer settings saved successfully', 3000, 'success');
         } catch (error) {
-            console.error('Error during credential validation:', error);
-            ui.showToast(`Error validating credentials: ${error.message}`, 3000, 'error');
+            console.error('Failed to save visualizer plugin settings:', error);
+            ui.showToast(`Failed to save to decent.app plugin: ${error.message}`, 3000, 'error');
         }
     });
 }
@@ -5137,6 +5151,14 @@ async function loadVisualizerSettings() {
 
         // Always clear the password field for security
         passwordInput.value = '';
+
+        // Secure values are returned as { isSet } state, never plaintext (decaid #588).
+        const passwordVal = savedSettings?.Password;
+        visualizerPasswordIsSet = passwordVal != null &&
+            (typeof passwordVal === 'object' ? passwordVal.isSet === true : !!passwordVal);
+        passwordInput.placeholder = visualizerPasswordIsSet
+            ? 'Password saved — leave empty to keep'
+            : 'Enter your Visualizer password';
 
         const autoUploadValue = typeof savedSettings.AutoUpload !== 'undefined' ? savedSettings.AutoUpload : true;
         autoUploadCheckbox.checked = !!autoUploadValue;


### PR DESCRIPTION
## What

decaid PR [decentespresso/decaid#588](https://github.com/decentespresso/decaid/pull/588) made a breaking change to the plugins settings API:

- **GET/POST** `/api/v1/plugins/:id/settings` no longer return secure setting values as plaintext — they come back as `{ "isSet": bool }` state objects.
- **POST** is now a patch: omitted fields preserve the existing value, `null` clears, and a `{ "isSet": ... }` object preserves the stored credential. The response is always redacted.

## Changes

- `src/modules/profile_selector.js` — `checkVisualizerCredentials()` read `settings.Password` as a string and returned it as `password`. Now it reads the `{isSet}` marker (with a legacy-cleartext fallback), derives `configured` from it, and returns `passwordSet` instead of a fake password value.
- `src/settings/settings.js` — Visualizer Extensions save flow now uses patch semantics: a typed password verifies + sets the credential; an empty field preserves the stored credential via `{isSet: true}` (no more forced password re-entry); load shows a "Password saved — leave empty to keep" placeholder when a credential is set.
- `rest_v1.yml` — ported the `PluginSettings` schema and patch/isSet endpoint descriptions from the decaid spec.

## Notes

- The `initSettingsModal` visualizer form in `src/modules/ui.js` targets DOM elements that don't exist in any HTML — dead code, left untouched.
- Verified: `node --check` on both edited JS files, YAML parses, full `npm test` suite green (231/231).
