### PR TITLE
[P3] Make version-dialog test line-ending agnostic

### DIFF
--- a/test/version_dialog.test.mjs
+++ b/test/version_dialog.test.mjs
@@ -3,7 +3,7 @@
 import { readFileSync } from 'fs';
 import assert from 'assert';
 
-const src  = readFileSync('src/modules/profile_editor.js', 'utf8');
+const src  = readFileSync('src/modules/profile_editor.js', 'utf8').replace(/\r\n?/g, '\n');
 const i    = src.indexOf('// Version picker. Returns the chosen ProfileRecord');
 const body = src.slice(i, src.indexOf('\n}\n\nasync function openVersionHistory()', i) + 2);
 


### PR DESCRIPTION
## Finding
F-003: Version-dialog test assumes LF line endings.

## Verification
- node --test test/version_dialog.test.mjs
- git diff --check
- rebased onto current main at 511f903