### PR TITLE
[P2] Sync API contract copies with Decaid

### DIFF
--- a/rest_v1.yml
+++ b/rest_v1.yml
@@ -144,10 +144,32 @@ paths:
       responses:
         "200":
           description: "Device connected successfully"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceConnectResult"
         "400":
           description: "Missing deviceId"
         "404":
           description: "Device not found"
+        "409":
+          description: "Connection conflicts with another operation or a stale selection"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceConnectResult"
+        "503":
+          description: "Device transport currently unavailable"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceConnectResult"
+        "504":
+          description: "Device connection timed out"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceConnectResult"
 
   /api/v1/devices/disconnect:
     put:
@@ -2585,6 +2607,43 @@ paths:
                   id:
                     type: string
 
+  /api/v1/plugins/{id}/{endpoint}:
+    get:
+      summary: Call a plugin HTTP endpoint
+      description: >
+        Routes the request to a loaded plugin's declared HTTP endpoint. The
+        runtime applies this contract to every HTTP method. The plugin manifest
+        must declare the api permission; otherwise Decaid rejects the request
+        before dispatch.
+      tags: [Plugins]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Plugin ID
+        - name: endpoint
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Plugin-declared HTTP endpoint ID
+      responses:
+        "403":
+          description: Plugin manifest does not declare the api permission
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [error]
+                properties:
+                  error:
+                    type: string
+                    example: "PluginPermissionError: Plugin example.plugin requires manifest permission api"
+        default:
+          description: Plugin-defined status, headers, and body
+
   /api/v1/plugins/install:
     post:
       summary: Install a plugin from URL
@@ -3873,6 +3932,14 @@ paths:
         - steams.json — all steam records
         - beans.json — all beans and batches
         - grinders.json — all grinders
+
+        Exports are streamed section-by-section through a bounded, file-backed
+        ZIP writer and served from a temporary file with a known
+        Content-Length; the full archive is never held in memory. A single
+        export may not exceed 2 GiB of uncompressed section data (400/500
+        error, use selected-section export). The archive is atomic: if any
+        requested section fails, an error is returned and no partial ZIP is
+        exposed.
       tags: [Data Management]
       responses:
         "200":
@@ -3911,6 +3978,28 @@ paths:
         recognized sections failed. Warnings and conflict skips do not cause
         207. Sections are not imported transactionally; a successful section
         is not rolled back when another section fails.
+
+        The request body is streamed into a temporary file; the whole archive
+        is never buffered in memory. Imports are bounded by the following
+        limits (exceeding any of them returns 400 with `Invalid backup
+        archive`):
+
+        - `maxImportRequestBytes` (default 2 GiB): compressed request size.
+        - `maxEntryCount` (default 4096): number of ZIP entries.
+        - `maxEntryUncompressedBytes` (default 1 GiB): per-entry uncompressed
+          size.
+        - `maxTotalUncompressedBytes` (default 2 GiB): sum of uncompressed
+          entry sizes (ZIP-bomb protection).
+        - `maxMetadataBytes` (default 64 KiB): metadata.json size.
+        - `maxRecordBytes` (default 64 MiB): individual JSON record size
+          (e.g. one shot, profile, or KV value).
+        - `maxFilenameBytes` / `maxExtraFieldBytes` / `maxCommentBytes`
+          (256 B / 64 KiB / 64 KiB): ZIP header field caps.
+
+        ZIP64 archives, encrypted entries, unsupported compression methods,
+        duplicate entry names, directory/symlink entries masquerading as
+        recognized files, truncated archives, CRC mismatches, and malformed
+        JSON all fail safely with 400.
       tags: [Data Management]
       parameters:
         - in: query
@@ -3995,6 +4084,24 @@ paths:
         results rather than HTTP 200 alone. Existing direct section maps stay
         under pull and push; phase metadata is additive under phases. Legacy
         remote import result maps are supported.
+
+        Pull responses are streamed to a temporary ZIP before import; push
+        requests stream a locally built temporary ZIP with a known content
+        length. The sync request body is limited to 1 MiB, and target
+        responses to 8 MiB. Transfers apply a connection timeout (10 s,
+        connect establishment only), an idle timeout (30 s between stream
+        events), and one deadline (10 min) per phase covering the network
+        stages (upload/download and response). Timeouts abort the request
+        at the transport level: a timed-out pull is cut off even while the
+        target is still generating its export (before headers) and never
+        starts its import; a timed-out push aborts its upload (and the
+        upload is backpressured, so the file is never read ahead of the
+        network). Local export and the pull-side import run to completion
+        and report their actual results. If the archive was already fully
+        uploaded before the deadline, the remote outcome is unknown and the
+        phase reports reason `timeout_unknown`. A generated archive is also
+        bounded by the 2 GiB import request limit, and per-record limits
+        are measured in UTF-8 bytes.
       tags: [Data Management]
       requestBody:
         required: true
@@ -4676,6 +4783,31 @@ components:
           type: string
           description: Error message (on failure)
 
+    DeviceConnectResult:
+      type: object
+      required: [deviceId, operation, outcome, state, connectionError]
+      properties:
+        deviceId:
+          type: string
+        operation:
+          type: string
+          enum: [connect]
+        outcome:
+          type: string
+          enum: [connected, alreadyConnected, conflict, failed, timedOut]
+        state:
+          type: string
+          enum: [discovered, connecting, connected, disconnecting, disconnected]
+        connectionError:
+          oneOf:
+            - $ref: '#/components/schemas/ConnectionError'
+            - type: object
+              nullable: true
+              enum: [null]
+        error:
+          type: string
+          nullable: true
+
     ConnectionError:
       type: object
       required: [kind, severity, timestamp, message]
@@ -4685,7 +4817,7 @@ components:
           description: >
             Error kind identifier. Skins should look up localized copy
             by this field. Initial set:
-            scaleConnectFailed, machineConnectFailed,
+            scaleConnectFailed, machineConnectFailed, sensorConnectFailed,
             scaleDisconnected, machineDisconnected,
             adapterOff, bluetoothPermissionDenied, scanFailed,
             profileUploadFailed.
@@ -4853,6 +4985,18 @@ components:
           type: integer
         steamTemperature:
           type: number
+        weight:
+          type: number
+          nullable: true
+          description: Bengle integrated-scale net weight in grams; null when unavailable.
+        weightFlow:
+          type: number
+          nullable: true
+          description: Bengle firmware gravimetric flow in g/s; null when unavailable.
+        milkTemperature:
+          type: number
+          nullable: true
+          description: Bengle milk-probe temperature in degrees Celsius; null when unavailable.
     MachineState:
       type: string
       enum:
@@ -5347,6 +5491,9 @@ components:
           type: boolean
           nullable: true
           description: When enabled and battery drops below 30%, screen brightness is capped at 20. Only effective on platforms with battery monitoring. Default value is true.
+        keepAwake:
+          type: boolean
+          description: When enabled, the wake lock stays on while the app is running, preventing the tablet screen from turning off. Default value is true.
         simulatedDevices:
           description: List of simulated device types to enable in scan results
           type: array
@@ -5440,6 +5587,9 @@ components:
         lowBatteryBrightnessLimit:
           type: boolean
           description: When enabled and battery drops below 30%, screen brightness is capped at 20. Only effective on platforms with battery monitoring.
+        keepAwake:
+          type: boolean
+          description: When enabled, the wake lock stays on while the app is running, preventing the tablet screen from turning off. Default value is true.
         simulatedDevices:
           description: List of simulated device types currently enabled in scan results
           type: array
@@ -5850,6 +6000,7 @@ components:
           type: number
         weightFlow:
           type: number
+          description: Device-provided gravimetric flow when available; otherwise Decaid's weight-derived estimate.
         battery:
           type: integer
           nullable: true
@@ -5878,7 +6029,7 @@ components:
           type: array
           items:
             type: string
-            enum: [log, api, emit, pluginStorage, pluginNotify, proxy.decent_api]
+            enum: [log, api, emit, pluginStorage, events.machine, events.shots, proxy.decent_api, proxy.decent_api.write]
         settings:
           description: Plugin settings schema
           type: object
@@ -5892,7 +6043,7 @@ components:
                 type: string
               type:
                 type: string
-                enum: ['websocket']
+                enum: ['websocket', 'http']
               data:
                 type: object
         loaded:

--- a/rest_v1.yml
+++ b/rest_v1.yml
@@ -391,10 +391,10 @@ paths:
       description: |
         Returns the optional capability surfaces the currently connected
         machine exposes. Plain DE1s return an empty list; Bengle returns
-        `["cupWarmer", "integratedScale"]` plus any future capabilities
-        as they ship. Skins should query this
-        endpoint once after connect to decide which UI to render and
-        which `/api/v1/machine/...` capability endpoints to call.
+        `["cupWarmer", "integratedScale", "ledStrip", "stopAtWeight"]`
+        plus any future capabilities as they ship. Skins should query this
+        endpoint once after connect to decide which UI to render and which
+        `/api/v1/machine/...` capability endpoints to call.
       tags: [Machine]
       responses:
         "200":
@@ -4428,6 +4428,116 @@ paths:
         "404":
           description: Unknown command or endpoint not available (non-simulate build)
 
+  /api/v1/debug/replay/shots:
+    get:
+      summary: List replay recordings and current selection (simulate=replay only)
+      description: |
+        Lists the bundled recordings the replay simulator (ReplayDE1) can play,
+        each addressable by a stable `id`, plus the currently forced selection.
+        Only meaningful when the connected machine is the replay simulator.
+      tags: [Debug]
+      responses:
+        "200":
+          description: Recordings listed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  selected:
+                    type: string
+                    nullable: true
+                    description: The forced recording id, or null for profile match.
+                  shots:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        profileTitle:
+                          type: string
+                          nullable: true
+        "400":
+          description: Connected machine is not the replay simulator
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        "404":
+          description: Endpoint not available (non-simulate build)
+
+  /api/v1/debug/replay/shot/{id}:
+    post:
+      summary: Force a replay recording for subsequent pulls (simulate=replay only)
+      description: |
+        Forces ReplayDE1 to play the recording with the given stable `id` on the
+        next espresso pulls, overriding profile-match/fallback selection. The
+        override is session-only. The normal machine-state API still starts and
+        stops the shot.
+      tags: [Debug]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Stable recording id from `GET /api/v1/debug/replay/shots`.
+      responses:
+        "200":
+          description: Recording forced
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  selected:
+                    type: string
+        "400":
+          description: Connected machine is not the replay simulator
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        "404":
+          description: Unknown recording id, or endpoint not available (non-simulate build)
+
+  /api/v1/debug/replay/shot:
+    delete:
+      summary: Clear the forced replay recording (simulate=replay only)
+      description: |
+        Clears any forced recording, returning ReplayDE1 to normal
+        profile-match/fallback selection.
+      tags: [Debug]
+      responses:
+        "200":
+          description: Override cleared
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  selected:
+                    type: string
+                    nullable: true
+        "400":
+          description: Connected machine is not the replay simulator
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        "404":
+          description: Endpoint not available (non-simulate build)
+
   /api/v1/feedback:
     post:
       summary: Submit feedback
@@ -4985,18 +5095,6 @@ components:
           type: integer
         steamTemperature:
           type: number
-        weight:
-          type: number
-          nullable: true
-          description: Bengle integrated-scale net weight in grams; null when unavailable.
-        weightFlow:
-          type: number
-          nullable: true
-          description: Bengle firmware gravimetric flow in g/s; null when unavailable.
-        milkTemperature:
-          type: number
-          nullable: true
-          description: Bengle milk-probe temperature in degrees Celsius; null when unavailable.
     MachineState:
       type: string
       enum:

--- a/websocket_v1.yml
+++ b/websocket_v1.yml
@@ -634,18 +634,6 @@ components:
           type: integer
         steamTemperature:
           type: number
-        weight:
-          type: number
-          nullable: true
-          description: Bengle integrated-scale net weight in grams; null when unavailable.
-        weightFlow:
-          type: number
-          nullable: true
-          description: Bengle firmware gravimetric flow in g/s; null when unavailable.
-        milkTemperature:
-          type: number
-          nullable: true
-          description: Bengle milk-probe temperature in degrees Celsius; null when unavailable.
     MachineState:
       type: string
       enum:
@@ -960,3 +948,4 @@ components:
           minimum: 0
           maximum: 100
           description: Brightness value (required when command is setBrightness).
+

--- a/websocket_v1.yml
+++ b/websocket_v1.yml
@@ -22,18 +22,31 @@ servers:
 channels:
   MachineSnapshot:
     address: ws/v1/machine/snapshot
-    description: Real-time snapshot data from the espresso machine.
+    description: >
+      The socket may be opened before any machine is connected. It remains open
+      and silent while no machine is attached, then automatically attaches when
+      the first machine appears. Every frame remains a MachineSnapshot; no
+      error or status frame is emitted on this typed telemetry channel.
+      The socket re-binds
+      across a machine instance swap: when the machine reconnects (for example
+      after a power-cycle) the server re-attaches this socket to the new machine
+      and frames simply resume. Clients do not need to reconnect.
+      Connection state remains available from /ws/v1/devices.
     messages:
       machineSnapshotMessage:
         $ref: '#/components/messages/MachineSnapshot'
   ShotSettings:
-    description: Real-time shot settings updates.
+    description: >
+      Real-time shot settings updates. Re-binds across a machine instance swap
+      — see MachineSnapshot.
     address: ws/v1/machine/shotSettings
     messages:
       shotSettingsMessage:
         $ref: '#/components/messages/ShotSettings'
   WaterLevels:
-    description: Real-time water level updates.
+    description: >
+      Real-time water level updates. Re-binds across a machine instance swap —
+      see MachineSnapshot.
     address: ws/v1/machine/waterLevels
     messages:
       waterLevelsMessage:
@@ -53,11 +66,25 @@ channels:
       scaleStatusMessage:
         $ref: '#/components/messages/ScaleStatus'
   MachineRaw:
-    description: Real-time raw BLE data from machine (read/write/notify).
+    description: >
+      Opening the socket before a machine connects does not close it. It remains
+      open and waits for attachment. A detached inbound command receives exactly
+      `{"error": "No machine connected"}`; it is not queued, and the socket
+      remains open after the error and attaches normally when a machine appears.
+      Bidirectional channel for raw BLE characteristic data (read/write/notify).
+      The server streams outbound data (notifications and read responses) and
+      accepts inbound commands (read/write requests). Re-binds across a machine
+      instance swap — see MachineSnapshot. Commands are delivered to the machine
+      the socket is currently bound to, not the one present when the socket was
+      opened.
     address: ws/v1/machine/raw
     messages:
       machineRawMessage:
         $ref: '#/components/messages/MachineRawMessage'
+      machineRawCommand:
+        $ref: '#/components/messages/MachineRawCommand'
+      machineRawError:
+        $ref: '#/components/messages/MachineRawError'
   ShotState:
     description: >
       Shot state + decision feed from the app's shot sequencer: state
@@ -113,12 +140,15 @@ channels:
       individual device connection state changes, scanning state changes,
       and ConnectionManager status updates (phase, found devices, ambiguity).
       Accepts commands to scan, connect, and disconnect devices.
+      Connect commands receive a DeviceConnectResult when the attempt finishes.
     address: ws/v1/devices
     messages:
       devicesState:
         $ref: '#/components/messages/DevicesState'
       devicesCommand:
         $ref: '#/components/messages/DevicesCommand'
+      deviceConnectResult:
+        $ref: '#/components/messages/DeviceConnectResult'
   Display:
     address: ws/v1/display
     description: |
@@ -172,10 +202,19 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/ScaleSnapshot'
-  machineRaw:
+  machineRawResponse:
     action: receive
     channel:
       $ref: '#/channels/MachineRaw'
+    messages:
+      - $ref: '#/channels/MachineRaw/messages/machineRawMessage'
+      - $ref: '#/channels/MachineRaw/messages/machineRawError'
+  machineRawCommand:
+    action: send
+    channel:
+      $ref: '#/channels/MachineRaw'
+    messages:
+      - $ref: '#/channels/MachineRaw/messages/machineRawCommand'
   sensorSnapshot:
     action: receive
     channel:
@@ -198,6 +237,7 @@ operations:
       $ref: '#/channels/Devices'
     messages:
       - $ref: '#/channels/Devices/messages/devicesState'
+      - $ref: '#/channels/Devices/messages/deviceConnectResult'
   devicesCommand:
     action: send
     channel:
@@ -266,6 +306,18 @@ components:
       title: Machine Raw BLE Message
       payload:
         $ref: '#/components/schemas/De1RawMessage'
+    MachineRawCommand:
+      name: MachineRawCommand
+      title: Machine Raw BLE Command
+      summary: Raw read/write request sent by the client.
+      payload:
+        $ref: '#/components/schemas/De1RawMessage'
+    MachineRawError:
+      name: MachineRawError
+      title: Machine Raw Error
+      summary: Error response when a machine command cannot be delivered.
+      payload:
+        $ref: '#/components/schemas/MachineRawError'
     ShotStateEvent:
       name: ShotStateEvent
       title: Shot state / decision event
@@ -298,6 +350,12 @@ components:
       summary: Command sent by the client to scan, connect, or disconnect devices.
       payload:
         $ref: '#/components/schemas/DevicesCommand'
+    DeviceConnectResult:
+      name: DeviceConnectResult
+      title: Device connect command result
+      summary: Outcome returned after a connect command finishes.
+      payload:
+        $ref: '#/components/schemas/DeviceConnectResult'
     DisplayState:
       name: DisplayState
       title: Display state
@@ -330,6 +388,16 @@ components:
           type: string
         st:
           type: string
+    MachineRawError:
+      type: object
+      description: Error returned when a raw command is sent while no machine is connected.
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - No machine connected
     AppUpdateState:
       type: object
       description: Snapshot of the app-update state machine.
@@ -376,10 +444,16 @@ components:
           description: >
             Error kind identifier. Skins should look up localized copy
             by this field. Initial set:
-            scaleConnectFailed, machineConnectFailed,
+            scaleConnectFailed, machineConnectFailed, sensorConnectFailed,
             scaleDisconnected, machineDisconnected,
-            adapterOff, bluetoothPermissionDenied, scanFailed.
+            adapterOff, bluetoothPermissionDenied, scanFailed,
+            profileUploadFailed.
             New kinds may be added without a version bump.
+
+            profileUploadFailed is raised when a profile upload to the
+            machine fails and is being retried. It persists across phase
+            transitions and is retracted when a retry succeeds, the machine
+            disconnects, or the retry cycle is disposed.
         severity:
           type: string
           enum: [warning, error]
@@ -407,9 +481,9 @@ components:
     ScaleSnapshot:
       type: object
       description: >
-        Smoothed weight + flow frame emitted on `ws/v1/scale/snapshot`. Mirrors
-        the controller-level `WeightSnapshot` (raw scale frames are processed
-        through the flow calculator before broadcast).
+        Weight + flow frame emitted on `ws/v1/scale/snapshot`. Mirrors the
+        controller-level `WeightSnapshot`. Device-provided flow is passed
+        through; weight-only scales use Decaid's flow estimator.
       properties:
         timestamp:
           type: string
@@ -419,7 +493,7 @@ components:
           description: Current weight reading in grams.
         weightFlow:
           type: number
-          description: Smoothed weight-derived flow in g/s (moving average over the smoothing window).
+          description: Device-provided gravimetric flow when available; otherwise Decaid's smoothed weight-derived estimate.
         battery:
           type: integer
           nullable: true
@@ -560,6 +634,18 @@ components:
           type: integer
         steamTemperature:
           type: number
+        weight:
+          type: number
+          nullable: true
+          description: Bengle integrated-scale net weight in grams; null when unavailable.
+        weightFlow:
+          type: number
+          nullable: true
+          description: Bengle firmware gravimetric flow in g/s; null when unavailable.
+        milkTemperature:
+          type: number
+          nullable: true
+          description: Bengle milk-probe temperature in degrees Celsius; null when unavailable.
     MachineState:
       type: string
       enum:
@@ -777,6 +863,30 @@ components:
             forgotten via the REST /api/v1/devices/forget endpoint.
           example: true
 
+    DeviceConnectResult:
+      type: object
+      required: [deviceId, operation, outcome, state, connectionError]
+      properties:
+        deviceId:
+          type: string
+        operation:
+          type: string
+          enum: [connect]
+        outcome:
+          type: string
+          enum: [connected, alreadyConnected, conflict, failed, timedOut]
+        state:
+          type: string
+          enum: [discovered, connecting, connected, disconnecting, disconnected]
+        connectionError:
+          oneOf:
+            - $ref: '#/components/schemas/ConnectionError'
+            - type: "null"
+        error:
+          type: string
+          nullable: true
+          description: Human-readable command error on non-successful outcomes.
+
     DevicesCommand:
       type: object
       required:
@@ -794,8 +904,8 @@ components:
           description: Device identifier. Required for connect and disconnect commands.
         connect:
           type: boolean
-          description: Whether to auto-connect discovered devices (scan command only).
-          default: false
+          description: Whether to scan first and automatically fill missing machine and scale slots without replacing connected devices (scan command only).
+          default: true
         quick:
           type: boolean
           description: Fire-and-forget scan without waiting for results (scan command only).


### PR DESCRIPTION
## Finding
F-005: Repository API contract copies are stale.

## Verification
- parse rest_v1.yml and websocket_v1.yml with PyYAML
- git diff --check
- rebased onto current main at 511f903