### PR TITLE
[P1] Require firmware completion confirmation

### DIFF
--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -1866,9 +1866,7 @@ export async function getFirmwareCatalog() {
 // `error` or a truncated stream — a stream that ends without `done` means CRC
 // verification never confirmed, so it is NOT a success.
 async function consumeFirmwareStream(response, onProgress) {
-    // No streaming body (old middleware, or a proxy that buffered it): the POST
-    // still completed, so treat it as a legacy success rather than failing.
-    if (!response.body?.getReader) return;
+    if (!response.body?.getReader) throw new Error('Firmware response did not provide a progress stream');
 
     const reader = response.body.getReader();
     const decoder = new TextDecoder();

--- a/test/firmware-progress.test.mjs
+++ b/test/firmware-progress.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import {
     splitNdjson,
     normalizeFirmwareEvent,
@@ -7,6 +8,15 @@ import {
     initialFirmwareState,
     summarizeFirmwareCatalog,
 } from '../src/modules/firmware-progress.js';
+
+function loadConsumeFirmwareStream() {
+    const source = readFileSync(new URL('../src/modules/api.js', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+    const start = source.indexOf('async function consumeFirmwareStream');
+    const end = source.indexOf('export async function uploadFirmware', start);
+    assert.notEqual(start, -1);
+    assert.notEqual(end, -1);
+    return new Function('splitNdjson', 'advanceFirmwareState', 'initialFirmwareState', `${source.slice(start, end)}; return consumeFirmwareStream;`)(splitNdjson, advanceFirmwareState, initialFirmwareState);
+}
 
 /** Feed a stream of decoded chunks through framing + folding, as api.js does. */
 function runStream(chunks) {
@@ -38,6 +48,10 @@ test('lines split across chunk boundaries are reassembled', () => {
 test('a final line without a trailing newline is still parsed', () => {
     const { state } = runStream(['{"event":"erasing"}\n{"event":"done"}']);
     assert.equal(state.phase, 'done');
+});
+
+test('a response without a readable progress stream is not success', async () => {
+    await assert.rejects(loadConsumeFirmwareStream()({ body: null }), /did not provide a progress stream/);
 });
 
 test('blank and malformed lines are skipped, not thrown', () => {


### PR DESCRIPTION
## Finding
F-008: Missing firmware progress streams are reported as successful updates.

## Verification
- node --test test/firmware-progress.test.mjs
- git diff --check
- rebased onto current main at 511f903