### PR TITLE
[P1] Preserve profile until replacement creation

### DIFF
--- a/src/modules/profile_editor.js
+++ b/src/modules/profile_editor.js
@@ -1973,6 +1973,9 @@ async function saveProfile() {
             // rehash. The new record links back via parentId, so /lineage returns
             // the full history the Revert picker reads.
             saved = await uploadProfileWithParent(editorState.profile, src.id);
+            if (saved.visibility !== 'visible') {
+                saved = await updateProfileVisibility(saved.id, 'visible');
+            }
             try { await updateProfileVisibility(src.id, 'hidden'); } catch (_) {}
         } else {
             // Presentation-only change (title/author/notes) → same id, PUT in place.

--- a/src/modules/profile_editor.js
+++ b/src/modules/profile_editor.js
@@ -1972,8 +1972,8 @@ async function saveProfile() {
             // hidden, restorable snapshot instead of letting the server drop it on
             // rehash. The new record links back via parentId, so /lineage returns
             // the full history the Revert picker reads.
-            try { await updateProfileVisibility(src.id, 'hidden'); } catch (_) {}
             saved = await uploadProfileWithParent(editorState.profile, src.id);
+            try { await updateProfileVisibility(src.id, 'hidden'); } catch (_) {}
         } else {
             // Presentation-only change (title/author/notes) → same id, PUT in place.
             saved = await updateProfile(src.id, editorState.profile);

--- a/test/profile-save-routing.test.mjs
+++ b/test/profile-save-routing.test.mjs
@@ -136,5 +136,23 @@ const uploadIndex = overwriteBranch.indexOf('saved = await uploadProfileWithPare
 const hideIndex = overwriteBranch.indexOf("await updateProfileVisibility(src.id, 'hidden')");
 assert.ok(uploadIndex >= 0 && hideIndex >= 0 && uploadIndex < hideIndex,
     'the replacement must exist before the visible predecessor is hidden');
+const reactivateIndex = overwriteBranch.indexOf("saved = await updateProfileVisibility(saved.id, 'visible')");
+assert.ok(reactivateIndex >= 0 && uploadIndex < reactivateIndex && reactivateIndex < hideIndex,
+    'a deduplicated hidden replacement must be reactivated before the predecessor is hidden');
+
+const reactivateBlock = overwriteBranch.match(/            if \(saved\.visibility !== 'visible'\) \{[\s\S]*?            \}/)?.[0];
+assert.ok(reactivateBlock, 'the save path must handle a deduplicated hidden replacement');
+const runReactivation = new Function('saved', 'updateProfileVisibility',
+    `return (async () => { ${reactivateBlock} return saved; })();`);
+const calls = [];
+const deduplicated = { id: 'profile:a', visibility: 'hidden' };
+const visibleReplacement = await runReactivation(deduplicated, async (id, visibility) => {
+    calls.push([id, visibility]);
+    return { ...deduplicated, visibility };
+});
+assert.strictEqual(visibleReplacement.visibility, 'visible',
+    'a deduplicated hidden profile must be reactivated');
+assert.deepStrictEqual(calls, [['profile:a', 'visible']],
+    'reactivation must target the deduplicated replacement id');
 
 console.log('profile-save-routing: all assertions passed');

--- a/test/profile-save-routing.test.mjs
+++ b/test/profile-save-routing.test.mjs
@@ -9,6 +9,7 @@
 //      the instant it opened and forked itself on a no-op Save.
 // Run: node test/profile-save-routing.test.mjs
 import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
 
 const deepCopy = o => JSON.parse(JSON.stringify(o));
 
@@ -126,5 +127,14 @@ const forked = asEdited(legacyDefault);
 forked.steps[0].seconds = 12;
 assert.strictEqual(route(legacyDefault, forked), 'fork-default',
     'editing a default forks it — PUT would be rejected');
+
+const editorSource = readFileSync(new URL('../src/modules/profile_editor.js', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const overwriteStart = editorSource.indexOf('        } else if (execChanged) {');
+const overwriteEnd = editorSource.indexOf('        } else {', overwriteStart + 1);
+const overwriteBranch = editorSource.slice(overwriteStart, overwriteEnd);
+const uploadIndex = overwriteBranch.indexOf('saved = await uploadProfileWithParent');
+const hideIndex = overwriteBranch.indexOf("await updateProfileVisibility(src.id, 'hidden')");
+assert.ok(uploadIndex >= 0 && hideIndex >= 0 && uploadIndex < hideIndex,
+    'the replacement must exist before the visible predecessor is hidden');
 
 console.log('profile-save-routing: all assertions passed');


### PR DESCRIPTION
## Finding
F-010: Profile version save hides the predecessor before replacement creation.

## Verification
- node --test test/profile-save-routing.test.mjs
- git diff --check
- rebased onto current main at 511f903