### PR TITLE
[P3] Treat settings search punctuation literally

### DIFF
--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -7714,7 +7714,8 @@ function renderFilteredSubcategories(mainCategoryKey, searchTerm) {
 function highlightMatch(text, searchTerm) {
     if (!searchTerm) return text;
 
-    const regex = new RegExp(`(${searchTerm})`, 'gi');
+    const escapedTerm = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escapedTerm})`, 'gi');
     return text.replace(regex, '<mark class="bg-yellow-300 text-black">$1</mark>');
 }
 

--- a/test/settings-search.test.mjs
+++ b/test/settings-search.test.mjs
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const source = readFileSync(new URL('../src/settings/settings.js', import.meta.url), 'utf8');
+const match = source.match(/function highlightMatch\(text, searchTerm\) \{[\s\S]*?\r?\n\}/);
+assert.ok(match);
+const highlightMatch = new Function(`${match[0]}\nreturn highlightMatch;`)();
+
+test('settings search highlights punctuation literally', () => {
+    const cases = [
+        ['Group (temperature)', '('],
+        ['Value [raw]', '['],
+        ['Path C:\\data', '\\'],
+        ['Version 1.2', '.'],
+    ];
+
+    for (const [text, term] of cases) {
+        const expected = text.replace(term, `<mark class="bg-yellow-300 text-black">${term}</mark>`);
+        assert.equal(highlightMatch(text, term), expected);
+    }
+});


### PR DESCRIPTION
## Finding
F-020: Settings search treats punctuation as regular-expression syntax.

## Verification
- node --test test/settings-search.test.mjs
- git diff --check
- rebased onto current main at 511f903