### PR TITLE
fix: drop dead _blank targets and the stale waterLevels writer

### DIFF
--- a/src/modules/waterTank.js
+++ b/src/modules/waterTank.js
@@ -1,4 +1,4 @@
-import { REA_PORT, WS_PROTOCOL, API_BASE_URL } from './api.js';
+import { REA_PORT, WS_PROTOCOL } from './api.js';
 import { logger } from './logger.js';
 import { createSocketSlot } from './socket-slot.js';
 // Note: This assumes ReconnectingWebSocket is globally available as it is in other files.
@@ -55,27 +55,11 @@ if (typeof window !== 'undefined') {
     window.refreshWaterTankUnit = refreshWaterTankUnit;
 }
 
-export async function setWaterLevelWarning(percentage) {
-    try {
-        const response = await fetch(`${API_BASE_URL}/de1/waterLevels`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ warningThresholdPercentage: percentage }),
-        });
-
-        if (response.status !== 202) {
-            const errorBody = await response.text();
-            throw new Error(`Failed to set water level warning. Status: ${response.status}, Body: ${errorBody}`);
-        }
-        logger.info(`Water level warning successfully set to ${percentage}%`);
-        return true;
-    } catch (error) {
-        logger.error('Error setting water level warning:', error);
-        throw error; // Re-throw to allow calling code to handle it
-    }
-}
+// setWaterLevelWarning lived here: it POSTed to /de1/waterLevels, a path that has
+// not existed since the machine namespace rename, carrying a
+// warningThresholdPercentage field the WaterLevels schema has no room for. It had
+// no callers, so nothing noticed. Use api.js setWaterLevels(refillLevel) — the
+// spec's only supported write to this endpoint.
 
 // The waterLevels socket is one of the sockets reaprime binds to a De1 *instance*
 // (de1handler.dart `_withDe1Ws`), so app.js re-opens it after a machine

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -1534,7 +1534,7 @@ export function renderUserManualSettings() {
                         <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
                             <p class="leading-[1.2]" data-i18n-key="Online Help">Online Help</p>
                         </div>
-                        <a href="https://decentespresso.com/support/submit" target="_blank" class="bg-[#385a92] h-[72px] px-[48px] rounded-[72px] text-white text-[24px] font-bold flex items-center justify-center">
+                        <a href="https://decentespresso.com/support/submit" class="bg-[#385a92] h-[72px] px-[48px] rounded-[72px] text-white text-[24px] font-bold flex items-center justify-center">
                             Visit
                         </a>
                     </div>
@@ -1555,7 +1555,7 @@ export function renderUserManualSettings() {
                         <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
                             <p class="leading-[1.2]" data-i18n-key="Tutorials">Tutorials</p>
                         </div>
-                        <a href="https://decentespresso.com/doc/quickstart/" target="_blank" class="bg-[#385a92] h-[72px] px-[48px] rounded-[72px] text-white text-[24px] font-bold flex items-center justify-center">
+                        <a href="https://decentespresso.com/doc/quickstart/" class="bg-[#385a92] h-[72px] px-[48px] rounded-[72px] text-white text-[24px] font-bold flex items-center justify-center">
                             View
                         </a>
                     </div>
@@ -1570,7 +1570,7 @@ export function renderUserManualSettings() {
                         <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
                             <p class="leading-[1.2]">Start writing your own skin.</p>
                         </div>
-                        <a href="https://github.com/decentespresso/decaid/blob/main/doc/Skins.md#skinsmd" target="_blank" class="bg-[#385a92] h-[72px] px-[48px] rounded-[72px] text-white text-[24px] font-bold flex items-center justify-center">
+                        <a href="https://github.com/decentespresso/decaid/blob/main/doc/Skins.md#skinsmd" class="bg-[#385a92] h-[72px] px-[48px] rounded-[72px] text-white text-[24px] font-bold flex items-center justify-center">
                             View
                         </a>
                     </div>
@@ -4530,7 +4530,6 @@ export function renderMainDescalingSettings() {
                         Run a descaling cycle to remove mineral buildup
                     </p>
                     <a href="https://app.basecamp.com/3671212/buckets/7351439/documents/7743429669"
-                       target="_blank" rel="noopener"
                        class="font-['Inter:Semi_Bold',sans-serif] font-semibold leading-[1.4] not-italic text-[#385a92] underline text-[24px]"
                        data-i18n-key="Descaling Instruction">
                         Descaling Instruction
@@ -5485,7 +5484,7 @@ function renderAppUpdateBlock(state) {
     } else if (phase === 'available') {
         action = state?.installable
             ? `<button onclick="window.installAppUpdate()" class="bg-[#2e7d32] h-[60px] px-[40px] rounded-[60px] text-white text-[22px] font-bold">${getTranslation('Update App')}${latest ? ' v' + latest : ''}</button>`
-            : `<a href="${state?.releaseUrl || '#'}" target="_blank" rel="noopener" class="bg-[#385a92] h-[60px] px-[40px] rounded-[60px] text-white text-[22px] font-bold flex items-center">View Release</a>`;
+            : `<a href="${state?.releaseUrl || '#'}" class="bg-[#385a92] h-[60px] px-[40px] rounded-[60px] text-white text-[22px] font-bold flex items-center">View Release</a>`;
     } else if (phase === 'downloading' || phase === 'installing') {
         action = `<button disabled class="bg-[#385a92] opacity-50 h-[60px] px-[40px] rounded-[60px] text-white text-[22px] font-bold">${getTranslation('Updating')}…</button>`;
     }
@@ -6558,7 +6557,7 @@ export async function initializeSettings() {
             });
             statusEl.innerHTML = `
                 <span class="text-green-600 font-bold text-[24px]" data-i18n-key="Submitted!">Submitted!</span>
-                ${data.issueUrl ? `<a href="${data.issueUrl}" target="_blank"
+                ${data.issueUrl ? `<a href="${data.issueUrl}"
                    class="ml-3 text-[#385a92] underline text-[22px]">View issue</a>` : ''}`;
             document.getElementById('feedback-title').value = '';
             document.getElementById('feedback-description').value = '';

--- a/visulizer_REAPLUGIN/settings.reaplugin/dist/settings.reaplugin/plugin.js
+++ b/visulizer_REAPLUGIN/settings.reaplugin/dist/settings.reaplugin/plugin.js
@@ -1307,7 +1307,7 @@ var createPlugin = (function() {
             <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
               <p class="leading-[1.2]">Online Help</p>
             </div>
-            <a href="https://decentespresso.com/support/submit" target="_blank" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
+            <a href="https://decentespresso.com/support/submit" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
               Visit
             </a>
           </div>
@@ -1327,7 +1327,7 @@ var createPlugin = (function() {
             <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
               <p class="leading-[1.2]">Tutorials</p>
             </div>
-            <a href="https://decentespresso.com/doc/quickstart/" target="_blank" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
+            <a href="https://decentespresso.com/doc/quickstart/" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
               View
             </a>
           </div>
@@ -1343,7 +1343,7 @@ var createPlugin = (function() {
             <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
               <p class="leading-[1.2]">Start writing your own skin.</p>
             </div>
-            <a href="https://github.com/decentespresso/decaid/blob/main/doc/Skins.md#skinsmd" target="_blank" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
+            <a href="https://github.com/decentespresso/decaid/blob/main/doc/Skins.md#skinsmd" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
               View
             </a>
           </div>

--- a/visulizer_REAPLUGIN/settings.reaplugin/streamline-setting.reaplugin/plugin.js
+++ b/visulizer_REAPLUGIN/settings.reaplugin/streamline-setting.reaplugin/plugin.js
@@ -1307,7 +1307,7 @@ var createPlugin = (function() {
             <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
               <p class="leading-[1.2]">Online Help</p>
             </div>
-            <a href="https://decentespresso.com/support/submit" target="_blank" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
+            <a href="https://decentespresso.com/support/submit" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
               Visit
             </a>
           </div>
@@ -1327,7 +1327,7 @@ var createPlugin = (function() {
             <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
               <p class="leading-[1.2]">Tutorials</p>
             </div>
-            <a href="https://decentespresso.com/doc/quickstart/" target="_blank" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
+            <a href="https://decentespresso.com/doc/quickstart/" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
               View
             </a>
           </div>
@@ -1343,7 +1343,7 @@ var createPlugin = (function() {
             <div class="flex flex-col font-['Inter:Bold',sans-serif] font-bold justify-center leading-[0] not-italic relative text-[#385a92] text-[30px]">
               <p class="leading-[1.2]">Start writing your own skin.</p>
             </div>
-            <a href="https://github.com/decentespresso/decaid/blob/main/doc/Skins.md#skinsmd" target="_blank" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
+            <a href="https://github.com/decentespresso/decaid/blob/main/doc/Skins.md#skinsmd" class="bg-[#385a92] h-[62.88px] rounded-[10px] w-[200px] text-white text-[24px] font-bold flex items-center justify-center">
               View
             </a>
           </div>


### PR DESCRIPTION
Follow-up to the 21-PR merge train — the two items flagged as out of scope there.

## `target="_blank"` (9 sites)

Contrary to the project's same-frame navigation rule: the webview host only opens the OS browser when a top-level navigation reaches its `shouldOverrideUrlLoading` hook, and `_blank` routes to the unhandled `onCreateWindow` instead.

In practice `app.js:1709` already intercepts every external anchor and drives `window.location.assign()`, in both the browser and the webview — so the attribute was already dead and **removing it changes no behaviour**. It just stops the next link from copying a broken pattern.

Removed from all six sites in `settings.js` and three in each hand-inlined `plugin.js` copy. `rel="noopener"` went with it where it only existed to guard the new window.

## `waterTank.setWaterLevelWarning`

Deleted. It POSTed to `/de1/waterLevels` — a path that has not existed since the machine namespace rename — carrying a `warningThresholdPercentage` field the `WaterLevels` schema does not define (spec: `refillLevel` only, "Only the refillLevel field is used").

It had no callers anywhere in the repo, so nothing noticed. Deleted rather than repaired, because fixing the path alone would leave a function the server still ignores; `api.js` `setWaterLevels(refillLevel)` already does this correctly. Drops the now-unused `API_BASE_URL` import.

## Checks

- `npm test` — 252 pass / 0 fail
- `node --check` on every edited file
- Both `plugin.js` copies edited identically; their only remaining difference is the pre-existing `id` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)