### PR TITLE
fix: stop the share-code Import button overlapping Notes

### DIFF
--- a/src/modules/profile_editor.js
+++ b/src/modules/profile_editor.js
@@ -1220,7 +1220,14 @@ function renderSettingsTab() {
         shareInput.type = 'text';
         shareInput.maxLength = 4;
         shareInput.placeholder = 'ABCD';
-        shareInput.className = 'flex-1 h-[56px] text-[22px] font-bold text-center tracking-[6px] bg-[var(--box-color)] border-2 border-[var(--border-color)] rounded-[12px] outline-none focus:border-[var(--mimoja-blue)]';
+        // min-w-0: an input's min-content width comes from its size attribute (20 chars
+        // by default), and a flex item will not shrink below that. At text-[22px] with
+        // tracking-[6px] those 20 characters are wider than the whole middle column, so
+        // the shrink-0 Import button got pushed past the column edge and rendered on top
+        // of the Notes column. size=4 matches maxLength so the intrinsic width is honest
+        // even if the flex context changes later.
+        shareInput.size = 4;
+        shareInput.className = 'flex-1 min-w-0 h-[56px] text-[22px] font-bold text-center tracking-[6px] bg-[var(--box-color)] border-2 border-[var(--border-color)] rounded-[12px] outline-none focus:border-[var(--mimoja-blue)]';
         shareInput.addEventListener('input', () => { shareInput.value = shareInput.value.toUpperCase().replace(/[^A-Z0-9]/g, ''); });
 
         const shareImportBtn = document.createElement('button');


### PR DESCRIPTION
## The bug

In the profile editor, creating a **new** profile → *Import from Share Code*: the Import button is clipped by / painted over the Notes column on the right.

## Cause

The row is `flex-1` input + `shrink-0` button. An `<input>`'s min-content width comes from its `size` attribute, which defaults to **20 characters**, and a flex item will not shrink below its min-content width. At `text-[22px]` with `tracking-[6px]` those 20 characters are ~400px — wider than the middle column itself (~440px at 1920px, and the button needs ~118px of that). So the row overflows and the button renders on top of the Notes column.

`src/modules/profile_editor.js:1016` documents an earlier fix for the same visual symptom, which set the column flex ratios to 1:1:2 with `min-w-0`. That fixed the columns; the input inside the middle column still had its own intrinsic floor.

## Fix

`min-w-0` on the input so it can shrink to the space actually available, plus `size=4` to match `maxLength` so the intrinsic width is honest if the flex context changes later. Only affects the new-profile editor, where this section renders.

## Checks

- `npm test` — 252 pass / 0 fail
- `node --check src/modules/profile_editor.js`
- No CSS rebuild required: `min-w-0` is already compiled into `src/css/app.css`
- Checked the other share-code input (`profile_selector.html`) — it is `w-full` with buttons on their own row, so it does not have this pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)