### PR TITLE
docs: embed the walkthrough videos in the user manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ https://github.com/user-attachments/assets/fe61e277-34b1-488b-b40f-d07536eead59
 
 🎬 **Importing from inside the skin.** The same data brought in from the skin side.
 
-https://github.com/user-attachments/assets/1bd6a845-55d9-48f3-9764-fd1490874031
+https://github.com/user-attachments/assets/e9a01cce-31a1-4e6d-b858-4d970db71739
 
 First-run setup walks through a short sequence:
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,13 @@ existing data**. Accept it. This is the easiest way to carry over what you alrea
 Decaid reads `de1app`'s own files, including `settings.tdb` and the DYE plugin's `grinders.tdb`. It
 brings across your settings, profiles, shot history, beans and grinders.
 
-> 🎬 **Video — Importing your de1app data.** The first-run import, start to finish.
->
-> 🎬 **Video — Importing from inside the skin.** The same data brought in from the skin side.
+🎬 **Importing your de1app data.** The first-run import, start to finish.
+
+https://github.com/user-attachments/assets/fe61e277-34b1-488b-b40f-d07536eead59
+
+🎬 **Importing from inside the skin.** The same data brought in from the skin side.
+
+https://github.com/user-attachments/assets/1bd6a845-55d9-48f3-9764-fd1490874031
 
 First-run setup walks through a short sequence:
 
@@ -127,7 +131,9 @@ and connect.
 
 Decaid remembers your machine and auto-connects on later starts.
 
-> 🎬 **Video — Connecting your machine.** Scanning for a DE1 and pairing it.
+🎬 **Connecting your machine.** Scanning for a DE1 and pairing it.
+
+https://github.com/user-attachments/assets/a12ff0f1-82b1-4b7e-88c3-4a432e220c90
 
 Scales work the same way. Connect yours once, then enable auto-connect so it returns on its own.
 
@@ -148,7 +154,9 @@ supported:
 Decaid's skin registry also carries community skins: Passione, OverDose, Beanie, NSX and WorkFlow.
 They install the same way. This manual does not cover them.
 
-> 🎬 **Video — Switching skins.** Finding the skin list, installing one, and making it the default.
+🎬 **Switching skins.** Finding the skin list, installing one, and making it the default.
+
+https://github.com/user-attachments/assets/d0dc9b10-8bd3-4928-8bcf-21526e6b9615
 
 **To leave a skin and return to Decaid's dashboard: swipe right from the left edge of the screen.**
 Your device's back gesture works too.
@@ -473,7 +481,9 @@ Derek answers questions about your DE1 and your equipment, and can look at a spe
 
 The same menu offers **Copy Shot Summary** if you only want the text.
 
-> 🎬 **Video — Asking Derek about a shot.** Copying a shot summary and asking a question.
+🎬 **Asking Derek about a shot.** Copying a shot summary and asking a question.
+
+https://github.com/user-attachments/assets/29869256-d63a-40ed-b8d3-2bf2876501ea
 
 Derek is not limited to shots you paste in — you can ask it general DE1 and equipment questions too.
 


### PR DESCRIPTION
Embeds the five `edu-video` walkthroughs in the user manual as inline video players.

Each clip was uploaded as a GitHub user-attachment and its URL placed on its own
unquoted line, which is what makes GitHub render a real `<video>` player. The five
`🎬` placeholders moved out of blockquotes for that reason.

| Placeholder | Source | Uploaded |
|---|---|---|
| Importing your de1app data | `import from de1app.mp4` | 7.1 MB, as-is |
| Importing from inside the skin | `importinskin.mp4` | 5.6 MB, as-is |
| Connecting your machine | `連機.mov` | 1.8 MB, 720p mp4 |
| Switching skins | `改皮膚.mov` | 7.3 MB, 720p mp4 |
| Asking Derek about a shot | `derek.mov` | 8.4 MB, 540p mp4 |

The `.mov` sources were re-encoded with `avconvert` to fit the attachment limit.
Originals in `edu-video/` are untouched, and nothing binary was added to the repo.

Playback verified against an anonymous (logged-out) fetch of the rendered page:
all five URLs resolve to signed srcs and return `200 video/mp4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
