### PR TITLE
docs: stop the browser address reading as literal text

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,15 @@ The skin also runs in an ordinary browser. Decaid serves it on **port 3000**:
 http://localhost:3000
 ```
 
-From another device on the same network, use the tablet's address — `http://<tablet-ip>:3000`.
+From another device on the same network, replace `localhost` with the tablet's own IP address —
+the four numbers your router gave it, which you will find in the tablet's Wi‑Fi settings. If the
+tablet is `192.168.1.42`, you type:
+
+```
+http://192.168.1.42:3000
+```
+
+Your tablet's numbers will differ. Type its address, not the one in the example.
 
 **The in-app web view is the primary way to use a skin.** A browser is the secondary way. It is
 handy for checking the machine from a laptop or phone, and for development. Everything works in


### PR DESCRIPTION
`http://<tablet-ip>:3000` reads as something to copy verbatim into the address
bar, and the angle brackets are jargon.

Replaced with plain instructions: what the address is ("the four numbers your
router gave it"), where to find it (the tablet's Wi-Fi settings), a worked
example in a code block, and an explicit line that your own numbers will differ.

Left alone on purpose: `{tablet-ip}` in `rest_v1.yml` and `websocket_v1.yml`,
where it is a declared OpenAPI/AsyncAPI server variable, and `docs/API.md`,
which is developer-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
