### PR TITLE
fix(skins): enter the new skin directly instead of exiting to the dashboard

### DIFF
--- a/docs/skin-switching.md
+++ b/docs/skin-switching.md
@@ -1,0 +1,60 @@
+# Switching skins from inside the webview
+
+Decaid serves the active skin folder on a **fresh ephemeral port every time**
+(`webui_service.dart` `_serveFresh` binds port 0 and never reuses a port it
+has already used). Switching the active skin therefore means restarting that
+server, and the page asking for the switch is left on an origin that no
+longer exists.
+
+## Why the dashboard exit cannot end a skin switch
+
+`window.decentApp.exitToDashboard()` navigates to
+`http://localhost:<port>/__decent/exit-dashboard`, where `<port>` is baked in
+by `buildSkinApiJavaScript()` when the page was served. Decaid's webview
+gates that navigation twice (`skin_view.dart`):
+
+1. `classifySkinNavigation()` accepts the URL only if it is string-equal to
+   `skinExitDashboardUrlForPort(<port Decaid is serving right now>)`, and
+2. `SkinExitCoordinator.tryStart()` additionally requires the page's own
+   top-level URL to be on that same port.
+
+The restart moves that port while the page stays where it was, so after a
+switch every exit URL available to us loses one check or the other:
+
+| exit URL | outcome |
+| --- | --- |
+| the port skin-api.js baked in (dead) | fails check 1 — `Blocking navigation to: http://localhost:<old>/__decent/exit-dashboard` |
+| the port `/webui/server/status` just reported | passes check 1, fails check 2 — `Rejected skin dashboard request` |
+| port 3000 | fails check 1 — the served port is never 3000 |
+
+A field log of six consecutive switch attempts shows exactly this: 46
+`Blocking navigation` lines and 4 `Rejected skin dashboard request` lines,
+with the only successful `Skin requested dashboard` in the whole log being an
+exit that had no server restart before it.
+
+## What works instead
+
+**Port 3000.** Decaid keeps it bound as a permanent 307 redirector to
+whatever port currently serves the skin (`_serveEntryPoint`), and
+`classifySkinNavigation()` allows port 3000 outright as well as the live
+serving port the redirect lands on. So after the restart,
+
+```js
+window.location.assign(`http://${hostname}:3000/?_=${Date.now()}`)
+```
+
+puts the new skin on screen with no dashboard round trip.
+
+Two things to keep true of any change here:
+
+- **Wait for the restart before navigating.** `waitForSkinServer()` polls
+  `GET /api/v1/webui/server/status` until it reports `serving`.
+- **Then wait a beat longer.** The webview compares against the port its own
+  view currently holds; a navigation sent before it picks the new port up is
+  classified as an external link and opens in the system browser instead of
+  the webview. The settle delay, and the single retry after it, exist for
+  that window.
+
+The plain "Go" exit button elsewhere in Settings is unaffected — it exits a
+skin whose server has not been restarted, which is the case the host gate was
+written for.

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -937,6 +937,12 @@ export function renderFlowMultiplierSettings(settings) {
 
 // Host exit, moved off the old floating home button. The host can inject its API
 // after this module runs, so decentApp is resolved on click, not at load.
+//
+// Only good while the skin server has not been restarted under us: the URL
+// skin-api.js bakes in carries the port this page was served on, and Decaid
+// compares it against the port it is serving right now (see setActiveSkin).
+// After a restart no exit URL can pass, which is why switching skins navigates
+// into the new skin rather than going out through the dashboard.
 function exitToDecentDashboard() {
     const app = window.decentApp;
     // Gate on __DECENT_HOST__, not on the function: skin-api.js is served to plain
@@ -8008,24 +8014,39 @@ export async function initializeSettings() {
                 ui.showToast('Skin set, but the web server did not come back. Restart Decaid.', 0, 'error');
                 return;
             }
-            // Straight out to the dashboard. The page cannot reload into the new skin:
-            // Decaid binds a fresh ephemeral port every time it serves a skin folder
-            // (webui_service.dart _serveFresh), so this origin is dead the moment the
-            // server restarts. Re-entering from the launcher builds SkinView against
-            // the current port -- and the launcher only offers "Return to skin" while
-            // the server is up, which is what the status poll above waited for.
-            ui.showToast('Skin set. Returning to the dashboard.', 6000, 'success');
-            exitToDecentDashboard();
-            // The host exit URL carries a port, and the host only honours the one it
-            // expects. skin-api.js baked in the port this page was served from, which
-            // the restart above just retired -- the log shows that URL coming back as
-            // "Blocking navigation to: http://localhost:<old>/__decent/exit-dashboard".
-            // So follow up with the same path on the port the server actually came back
-            // on. A /__decent/ URL the host does not recognise is blocked, never opened
-            // elsewhere, so trying both costs nothing.
-            setTimeout(() => {
-                window.location.assign(`${window.location.protocol}//${window.location.hostname}:${port}/__decent/exit-dashboard`);
-            }, 800);
+            // Go straight to the new skin instead of out to the dashboard.
+            //
+            // The dashboard exit cannot work here. Decaid's webview compares an
+            // exit URL against skinExitDashboardUrlForPort(<port it is serving
+            // right now>) and additionally requires the page's own top-level URL
+            // to be on that port (classifySkinNavigation + SkinExitCoordinator in
+            // skin_view.dart). The restart just moved that port, and this page is
+            // still on the old one, so every exit URL we can produce loses: the
+            // one skin-api.js baked in is the dead port ("Blocking navigation
+            // to: .../__decent/exit-dashboard"), and the port the restart came
+            // back on passes the URL check but fails the top-level check
+            // ("Rejected skin dashboard request").
+            //
+            // Port 3000 is the way out. Decaid keeps it bound as a permanent 307
+            // redirector to whatever port currently serves the skin
+            // (_serveEntryPoint), and the webview allows port 3000 outright plus
+            // the live serving port the redirect lands on. So one navigation puts
+            // the new skin on screen with no dashboard round trip.
+            ui.showToast('Skin set. Loading it now.', 6000, 'success');
+            // The redirect lands on the port Decaid is serving *at that moment*,
+            // and the webview only allows it once its own view has picked the new
+            // port up. Give it a beat: too early and the navigation is treated as
+            // an external link and opens in the system browser instead.
+            await new Promise(r => setTimeout(r, 1200));
+            const enterSkin = () => window.location.assign(
+                `${window.location.protocol}//${window.location.hostname}:3000/?_=${Date.now()}`);
+            enterSkin();
+            // Still here means the navigation was refused. One retry, then say so
+            // — the machine-side back gesture still reaches the dashboard.
+            setTimeout(enterSkin, 3000);
+            setTimeout(() => ui.showToast(
+                'Skin set, but this screen did not switch. Use system back to reach the dashboard, then open the skin.',
+                0, 'error'), 6000);
         } catch (error) {
             logger.error('Error setting active skin:', error);
             ui.showToast(`Failed to switch skin: ${error.message}`, 5000, 'error');


### PR DESCRIPTION
Diagnosed from a field log (`log.txt`, 27 Aug, macOS) plus `webview_console.log`.

## What the log shows

Six skin-switch attempts, all identical:

```
18:10:45.503  WebUIService - Stopping WebUI server on port 51683
18:10:45.508  POST /api/v1/webui/server/start          (new ephemeral port)
18:10:46.014  SkinView - Blocking navigation to: http://localhost:51683/__decent/exit-dashboard
18:10:46.814  SkinView - Rejected skin dashboard request
```

Same at 17:41:34, 17:46:25, 17:59:52, 18:06:14, 18:07:00, 18:10:23 — 46 `Blocking navigation` lines and 4 `Rejected skin dashboard request` lines in total. The one exit that *did* work, `18:01:34 Skin requested dashboard`, had no server restart before it.

The console log rules out the skin's own fallback path: no `[exit-dashboard] no host exit API` line, so `window.decentApp.exitToDashboard()` exists and is being called. The host is refusing it.

## Why

Decaid serves the skin folder on a **fresh ephemeral port every time** (`webui_service.dart` `_serveFresh` binds port 0 and never reuses a port). The restart in `setActiveSkin` therefore leaves this page on an origin that no longer exists, and `skin_view.dart` gates the exit URL twice:

1. `classifySkinNavigation()` — the URL must be string-equal to `skinExitDashboardUrlForPort(<port being served right now>)`.
2. `SkinExitCoordinator.tryStart()` — the page's own top-level URL must also be on that port.

After a restart, no exit URL available to the skin can pass both:

| exit URL we send | result |
| --- | --- |
| the port `skin-api.js` baked in (now dead) | fails check 1 → `Blocking navigation` |
| the port `/webui/server/status` just reported | passes 1, fails 2 (top-level URL is the old origin) → `Rejected skin dashboard request` |
| port 3000 | fails check 1 — the served port is never 3000 |

That last row means the `exitVia(3000)` shot added on main cannot work either. The three-shot exit was aiming at a door that is locked by construction once the server has restarted.

## The fix

Stop trying to leave, and go straight into the new skin. Port 3000 is the one stable address: Decaid keeps it bound as a permanent 307 redirector to whatever port currently serves the skin (`_serveEntryPoint`), and `classifySkinNavigation()` allows port 3000 outright **plus** the live serving port the redirect lands on. So after the restart:

```js
window.location.assign(`http://${hostname}:3000/?_=${Date.now()}`)
```

puts the new skin on screen with no dashboard round trip — which also answers the "can we switch skins without exiting" question: yes, this way.

Timing matters and is handled: the navigation waits for `/webui/server/status` to report `serving`, then a further 1.2 s, because the webview compares against the port *its own view* currently holds — sent too early, the redirect is classified as an external link and opens in the system browser instead. One retry 3 s later, then a toast naming the system back gesture rather than leaving the user staring at a dead page.

Also documents the gate in `docs/skin-switching.md`, and notes the restart caveat on `exitToDecentDashboard()` — that button is still correct for its own case (exiting a skin whose server has not been restarted), which is the case that works in the log.

## Testing

`npm test` — 443 pass, 0 fail (no behaviour here is unit-testable without a DOM and a live host; the sequence is awaits over `fetch` plus a navigation).

**Not verified on hardware.** This needs a run on the machine that produced the log: switch skins and confirm the new skin appears in place, with no `Blocking navigation` / `Rejected skin dashboard request` lines and no browser window opening.

The deeper fix belongs in Decaid — `SkinView` knows the served port changed and could reload the webview itself on `didUpdateWidget`, which would make this delay-and-retry dance unnecessary and would also rescue any skin stranded on a dead origin. Happy to open that PR separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfCnQuQG7i7obdVdkCRG69