### PR TITLE
Add Print The Shot to the Extensions settings

### DIFF
--- a/src/settings/settings-tree.js
+++ b/src/settings/settings-tree.js
@@ -68,7 +68,8 @@ export const SETTINGS_TREE = {
             { id: 'extention1', name: 'Visualizer', settingsCategory: 'extensions' },
             { id: 'shotupload', name: 'Shot Uploader', settingsCategory: 'shotupload', i18nKey: 'Shot Uploader' },
             { id: 'extention2', name: 'Plugins', settingsCategory: 'plugins' },
-            { id: 'dye2', name: 'DYE2', settingsCategory: 'dye2', i18nKey: 'DYE2' }
+            { id: 'dye2', name: 'DYE2', settingsCategory: 'dye2', i18nKey: 'DYE2' },
+            { id: 'printtheshot', name: 'Print The Shot', settingsCategory: 'printtheshot', i18nKey: 'Print The Shot' }
         ]
     },
     'miscellaneous': {

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -5569,22 +5569,259 @@ export function renderExtensionsSettings() {
     return template;
 }
 
-// Render Print The Shot settings — its own Extensions sub-page, embedding the
-// print-the-shot.reaplugin UI (shot browser, curve preview, print controls).
+// Print The Shot — settings UI for the bundled print-the-shot.reaplugin,
+// which uploads finished shots in TCL print format to a local print server.
+// Layout follows the other Extensions pages: native skin styling, stacked
+// vertically, with a plain-text shot browser instead of a chart.
+const PRINT_THE_SHOT_PLUGIN_ID = 'print-the-shot.reaplugin';
+const PRINT_THE_SHOT_DEFAULT_SETTINGS = {
+    AutoUpload: true,
+    ServerUrl: '',
+    ServerEndpoint: 'upload',
+    UseHttp: true,
+    MachineName: '',
+    MinSeconds: 6,
+};
+const PRINT_THE_SHOT_STATE = { offset: 0, shot: null, settings: null, processing: false };
+
 export function renderPrintTheShotSettings() {
-    const host = localStorage.getItem('reaHostname') || window.location.hostname;
+    setTimeout(setupPrintTheShotListeners, 0);
+
     return `
-        <div class="content-stretch flex flex-col gap-[30px] items-start relative w-full">
+        <div class="content-stretch flex flex-col gap-[40px] items-start relative w-full">
             <div class="flex flex-col font-['Inter:Semi_Bold',sans-serif] font-semibold justify-center leading-[0] min-w-full not-italic relative text-[var(--text-primary)] text-[36px] text-center w-[min-content]">
                 <p class="leading-[1.2]" data-i18n-key="Print The Shot">Print The Shot</p>
+                <p id="printtheshot-description" class="font-['Inter:Regular',sans-serif] font-normal leading-[1.4] not-italic relative text-[var(--text-primary)] text-[24px] w-full opacity-75"></p>
             </div>
-            <div class="content-stretch flex flex-col items-start relative w-full">
-                <iframe
-                    src="http://${host}:8080/api/v1/plugins/print-the-shot.reaplugin/ui"
-                    style="width: 100%; min-height: 82vh; border: none; border-radius: 12px; background: #1a1a2e;"
-                    title="Print The Shot"></iframe>
+
+            <!-- Current shot -->
+            <div class="content-stretch flex flex-col gap-[16px] items-start relative w-full">
+                <div class="content-stretch flex items-center justify-between relative w-full">
+                    <button id="printtheshot-prev" class="bg-[#385a92] h-[52px] px-[22px] rounded-[64px] text-white text-[20px] font-bold" data-i18n-key="Previous shot">◀ Previous shot</button>
+                    <div class="flex flex-col items-center gap-[4px] flex-1 text-center px-[16px]">
+                        <p id="printtheshot-shot-title" class="text-[24px] font-bold text-[var(--text-primary)] leading-[1.2]">Loading…</p>
+                        <p id="printtheshot-shot-meta" class="text-[20px] text-[var(--low-contrast-white)] leading-[1.3]"></p>
+                    </div>
+                    <button id="printtheshot-next" class="bg-[#385a92] h-[52px] px-[22px] rounded-[64px] text-white text-[20px] font-bold" data-i18n-key="Next shot">Next shot ▶</button>
+                </div>
+            </div>
+
+            <!-- Settings -->
+            <div class="content-stretch flex flex-col gap-[24px] items-start relative w-full">
+                <div class="content-stretch flex flex-col gap-[14px] items-start relative w-full">
+                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-server-url" data-i18n-key="Server address">Server address</label>
+                    <input id="printtheshot-server-url" type="text" class="w-full max-w-[500px] p-[12px] rounded-[10px] border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[22px] focus:outline-none focus:ring-2 focus:ring-[#385a92]" placeholder="192.168.1.20:8000">
+                </div>
+                <div class="content-stretch flex flex-col gap-[14px] items-start relative w-full">
+                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-server-endpoint" data-i18n-key="Upload path">Upload path</label>
+                    <input id="printtheshot-server-endpoint" type="text" class="w-full max-w-[500px] p-[12px] rounded-[10px] border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[22px] focus:outline-none focus:ring-2 focus:ring-[#385a92]">
+                </div>
+                <div class="content-stretch flex flex-col gap-[14px] items-start relative w-full">
+                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-machine-name" data-i18n-key="Machine name">Machine name</label>
+                    <input id="printtheshot-machine-name" type="text" class="w-full max-w-[500px] p-[12px] rounded-[10px] border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[22px] focus:outline-none focus:ring-2 focus:ring-[#385a92]" placeholder="DE1">
+                </div>
+                <div class="content-stretch flex flex-col gap-[14px] items-start relative w-full">
+                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-min-seconds" data-i18n-key="Minimum shot length (s)">Minimum shot length (s)</label>
+                    <input id="printtheshot-min-seconds" type="number" min="0" class="w-full max-w-[300px] p-[12px] rounded-[10px] border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[22px] focus:outline-none focus:ring-2 focus:ring-[#385a92]">
+                </div>
+                <div class="content-stretch flex items-center gap-[20px] relative w-full">
+                    <input id="printtheshot-use-http" type="checkbox" class="w-[36px] h-[36px] accent-[#385a92]">
+                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-use-http" data-i18n-key="Use HTTP">Use HTTP</label>
+                </div>
+                <div class="content-stretch flex items-center gap-[20px] relative w-full">
+                    <input id="printtheshot-auto-upload" type="checkbox" class="w-[36px] h-[36px] accent-[#385a92]">
+                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-auto-upload" data-i18n-key="Auto upload">Auto upload</label>
+                </div>
+            </div>
+
+            <!-- Actions -->
+            <div class="content-stretch flex flex-wrap gap-[16px] items-center relative w-full">
+                <button id="printtheshot-print" class="bg-[#385a92] h-[56px] px-[28px] rounded-[64px] text-white text-[22px] font-bold" data-i18n-key="Print current shot">Print current shot</button>
+                <button id="printtheshot-upload-last" class="bg-[var(--profile-button-background-color)] border border-[var(--border-color)] h-[56px] px-[28px] rounded-[64px] text-[var(--text-primary)] text-[22px] font-bold" data-i18n-key="Upload last shot">Upload last shot</button>
+                <button id="printtheshot-save" class="bg-[var(--profile-button-background-color)] border border-[var(--border-color)] h-[56px] px-[28px] rounded-[64px] text-[var(--text-primary)] text-[22px] font-bold" data-i18n-key="Save settings">Save settings</button>
+                <span id="printtheshot-status" class="text-[20px] text-[var(--low-contrast-white)]"></span>
+            </div>
+
+            <!-- Log -->
+            <div class="content-stretch flex flex-col gap-[10px] items-start relative w-full">
+                <div id="printtheshot-log" class="w-full min-h-[120px] max-h-[260px] overflow-y-auto p-[16px] rounded-[12px] border border-[var(--border-color)] bg-[var(--box-color)] text-[16px] leading-[1.5] text-[var(--text-primary)] font-mono"></div>
             </div>
         </div>`;
+}
+
+async function setupPrintTheShotListeners() {
+    const $ = (id) => document.getElementById(id);
+    const logEl = $('printtheshot-log');
+    const statusEl = $('printtheshot-status');
+    if (!logEl) return;
+
+    const log = (msg, level = 'info') => {
+        const line = document.createElement('div');
+        const time = new Date().toISOString().slice(11, 19);
+        line.textContent = `${time}  ${msg}`;
+        line.style.color = level === 'error' ? '#f87171' : level === 'success' ? '#4ade80' : 'var(--text-primary)';
+        logEl.appendChild(line);
+        logEl.scrollTop = logEl.scrollHeight;
+        while (logEl.childElementCount > 100) logEl.removeChild(logEl.firstChild);
+    };
+
+    const setStatus = (text) => { if (statusEl) statusEl.textContent = text || ''; };
+    const pluginApi = (endpoint) => `${API_BASE_URL}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/${endpoint}`;
+
+    const plugins = await getPlugins();
+    const plugin = Array.isArray(plugins) ? plugins.find(p => p?.id === PRINT_THE_SHOT_PLUGIN_ID) : null;
+    if (!plugin) {
+        log('Print The Shot plugin not loaded — update Decaid', 'error');
+        setStatus('Plugin not loaded');
+        return;
+    }
+    const descriptionEl = $('printtheshot-description');
+    if (descriptionEl && plugin.description) descriptionEl.textContent = getTranslation(plugin.description);
+
+    try {
+        const res = await fetch(`${API_BASE_URL}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/settings`);
+        if (res.ok) PRINT_THE_SHOT_STATE.settings = Object.assign({}, PRINT_THE_SHOT_DEFAULT_SETTINGS, await res.json());
+    } catch (e) {
+        PRINT_THE_SHOT_STATE.settings = Object.assign({}, PRINT_THE_SHOT_DEFAULT_SETTINGS);
+        log('Failed to load settings: ' + e.message, 'error');
+    }
+    const s = PRINT_THE_SHOT_STATE.settings;
+    $('printtheshot-server-url').value = s.ServerUrl || '';
+    $('printtheshot-server-endpoint').value = s.ServerEndpoint || '';
+    $('printtheshot-machine-name').value = s.MachineName || '';
+    $('printtheshot-min-seconds').value = s.MinSeconds ?? 6;
+    $('printtheshot-use-http').checked = !!s.UseHttp;
+    $('printtheshot-auto-upload').checked = !!s.AutoUpload;
+
+    const fetchShotAt = async (offset) => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/shots?limit=1&offset=${offset}`);
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            const data = await res.json();
+            return (data.items || [])[0] || null;
+        } catch (e) {
+            log('Failed to load shot: ' + e.message, 'error');
+            return null;
+        }
+    };
+
+    const showShot = (shot) => {
+        const titleEl = $('printtheshot-shot-title');
+        const metaEl = $('printtheshot-shot-meta');
+        if (!shot) { titleEl.textContent = 'No shots yet'; metaEl.textContent = ''; return; }
+        const wf = shot.workflow || {};
+        const when = new Date(shot.timestamp).toLocaleString();
+        const profile = (wf.profile && wf.profile.title) || '—';
+        const ann = shot.annotations || {};
+        const bean = ((shot.workflow || {}).context || {}).coffeeName || '';
+        titleEl.textContent = `${profile} · ${when}`;
+        metaEl.textContent = `in ${ann.actualDoseWeight ?? '?'}g · out ${ann.actualYield ?? '?'}g${bean ? ' · ' + bean : ''}`;
+    };
+
+    const loadShot = async () => {
+        const shot = await fetchShotAt(PRINT_THE_SHOT_STATE.offset);
+        if (!shot) {
+            if (PRINT_THE_SHOT_STATE.offset > 0) { log('No older shots', 'info'); PRINT_THE_SHOT_STATE.offset -= 1; }
+            else { log('Already at the latest shot', 'info'); }
+            return;
+        }
+        PRINT_THE_SHOT_STATE.shot = shot;
+        showShot(shot);
+    };
+
+    const machineId = (name) => {
+        const clean = String(name || '').replace(/[^A-Za-z0-9]/g, '');
+        return clean ? clean.slice(0, 20) : 'UNKNOWN';
+    };
+
+    const uploadShot = async (shot) => {
+        if (!shot) { log('No shot selected', 'warn'); return; }
+        const settings = PRINT_THE_SHOT_STATE.settings;
+        if (!settings.ServerUrl) { log('No server configured — set Server address and save', 'error'); return; }
+        if (PRINT_THE_SHOT_STATE.processing) return;
+        PRINT_THE_SHOT_STATE.processing = true;
+        try {
+            const fullRes = await fetch(`${API_BASE_URL}/shots/${shot.id}`);
+            if (!fullRes.ok) throw new Error('HTTP ' + fullRes.status);
+            const full = await fullRes.json();
+            const ms = full.measurements || [];
+            let duration = 0;
+            if (ms.length >= 2) {
+                const first = ms[0].machine && ms[0].machine.timestamp;
+                const last = ms[ms.length - 1].machine && ms[ms.length - 1].machine.timestamp;
+                duration = first && last ? Math.round((new Date(last).getTime() - new Date(first).getTime()) / 1000) : Math.round(ms.length * 0.24);
+            }
+            if (duration < settings.MinSeconds) { log(`Shot too short (${duration}s < ${settings.MinSeconds}s), skipping`, 'warn'); return; }
+
+            const ts = new Date().toISOString().replace(/[:.]/g, '').slice(0, 15);
+            const protocol = settings.UseHttp ? 'http' : 'https';
+            const server = String(settings.ServerUrl).replace(/^https?:[/][/]/, '');
+            const url = `${protocol}://${server}/${settings.ServerEndpoint}?machine_id=${machineId(settings.MachineName)}&timestamp=${ts}&plugin_version=${plugin.version}`;
+
+            log(`Printing shot ${shot.id.slice(0, 8)} → ${url}`, 'info');
+            for (let attempt = 1; attempt <= 3; attempt++) {
+                try {
+                    const res = await fetch(pluginApi('upload'), {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ url, shot: full }),
+                    });
+                    const data = await res.json();
+                    if (data && data.success) {
+                        log(`Print OK (attempt ${attempt})`, 'success');
+                        setStatus('OK');
+                        return;
+                    }
+                    log(`Attempt ${attempt} failed: ${(data && data.message) || (data && data.statusCode ? 'HTTP ' + data.statusCode : 'HTTP ' + res.status)}`, 'warn');
+                } catch (e) {
+                    log(`Attempt ${attempt} error: ${e.message}`, 'warn');
+                }
+                if (attempt < 3) await new Promise(r => setTimeout(r, 2000));
+            }
+            log('Print FAILED after 3 attempts', 'error');
+            setStatus('FAILED');
+        } catch (e) {
+            log('Upload error: ' + e.message, 'error');
+        } finally {
+            PRINT_THE_SHOT_STATE.processing = false;
+        }
+    };
+
+    $('printtheshot-prev').addEventListener('click', () => { PRINT_THE_SHOT_STATE.offset += 1; loadShot(); });
+    $('printtheshot-next').addEventListener('click', () => {
+        if (PRINT_THE_SHOT_STATE.offset === 0) { log('Already at the latest shot', 'info'); return; }
+        PRINT_THE_SHOT_STATE.offset -= 1; loadShot();
+    });
+    $('printtheshot-print').addEventListener('click', () => uploadShot(PRINT_THE_SHOT_STATE.shot));
+    $('printtheshot-upload-last').addEventListener('click', async () => {
+        const shot = await fetchShotAt(0);
+        if (shot) { PRINT_THE_SHOT_STATE.offset = 0; PRINT_THE_SHOT_STATE.shot = shot; showShot(shot); uploadShot(shot); }
+    });
+    $('printtheshot-save').addEventListener('click', async () => {
+        const next = {
+            AutoUpload: $('printtheshot-auto-upload').checked,
+            ServerUrl: $('printtheshot-server-url').value.trim(),
+            ServerEndpoint: $('printtheshot-server-endpoint').value.trim() || 'upload',
+            UseHttp: $('printtheshot-use-http').checked,
+            MachineName: $('printtheshot-machine-name').value.trim(),
+            MinSeconds: parseInt($('printtheshot-min-seconds').value, 10) || 0,
+        };
+        try {
+            const res = await fetch(`${API_BASE_URL}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/settings`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(next),
+            });
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            PRINT_THE_SHOT_STATE.settings = next;
+            log('Settings saved', 'success');
+        } catch (e) {
+            log('Failed to save settings: ' + e.message, 'error');
+        }
+    });
+
+    await loadShot();
+    log(`Print The Shot v${plugin.version} initialized`, 'info');
 }
 
 // Render DYE2 (Describe Your Espresso 2) settings — its own Extensions sub-page.

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -687,6 +687,8 @@ export function renderSettingsContent(category) {
             return renderShotUploadSettings();
         case 'dye2':
             return renderDye2Settings();
+        case 'printtheshot':
+            return renderPrintTheShotSettings();
         case 'extensions':
         case 'extention1':
         case 'extention2':
@@ -5565,6 +5567,24 @@ export function renderExtensionsSettings() {
     setTimeout(setupVisualizerEventListeners, 0);
 
     return template;
+}
+
+// Render Print The Shot settings — its own Extensions sub-page, embedding the
+// print-the-shot.reaplugin UI (shot browser, curve preview, print controls).
+export function renderPrintTheShotSettings() {
+    const host = localStorage.getItem('reaHostname') || window.location.hostname;
+    return `
+        <div class="content-stretch flex flex-col gap-[30px] items-start relative w-full">
+            <div class="flex flex-col font-['Inter:Semi_Bold',sans-serif] font-semibold justify-center leading-[0] min-w-full not-italic relative text-[var(--text-primary)] text-[36px] text-center w-[min-content]">
+                <p class="leading-[1.2]" data-i18n-key="Print The Shot">Print The Shot</p>
+            </div>
+            <div class="content-stretch flex flex-col items-start relative w-full">
+                <iframe
+                    src="http://${host}:8080/api/v1/plugins/print-the-shot.reaplugin/ui"
+                    style="width: 100%; min-height: 82vh; border: none; border-radius: 12px; background: #1a1a2e;"
+                    title="Print The Shot"></iframe>
+            </div>
+        </div>`;
 }
 
 // Render DYE2 (Describe Your Espresso 2) settings — its own Extensions sub-page.

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -1,5 +1,5 @@
 import { isEcoSteamEnabled, setEcoSteamEnabled } from '../modules/eco-steam.js';
-import {  getReaSettings, getDe1Settings, getDe1AdvancedSettings, setReaSettings, setDe1Settings, setDe1AdvancedSettings, resetDe1Settings, setMachineState, connectScaleDevice, connectDeviceWebSocket, sendDeviceCommand, awaitDeviceConnectResult, dimDisplay, restoreDisplay, isBlackScreenSaver, setBlackScreenSaver as apiSetBlackScreenSaver, rememberBrightness, getLastDisplayState, currentMachineState, signalHeartbeat, MachineState, getDeviceWebSocket, initDeviceWebSocketWithCallback, saveScaleDeviceId, getScaleDeviceId, connectDisplayWebSocket, sendDisplayCommand, connectUpdateWebSocket, sendUpdateCommand, enableWakeLock, disableWakeLock, isWakeLockEnabled, getPresenceSettings, setPresenceSettings, getPresenceSchedules, createPresenceSchedule, updatePresenceSchedule, deletePresenceSchedule, getAppInfo, getMachineInfo, getWorkflow, updateWorkflow, getAllSkins, getDefaultSkin, setDefaultSkin, updateSkins, stopWebuiServer, startWebuiServer, getWebuiServerStatus, uploadFirmware, applyFirmware, cancelFirmwareUpdate, getFirmwareCatalog, setWaterLevels, API_BASE_URL, listWifiScales, addWifiScale, removeWifiScale, forgetDevice, getLedStrip, setLedStrip, commitLedStrip, resetLedStrip, previewLedStrip, clearLedStripPreview, getCupWarmer, setCupWarmer, setCupWarmerPrewarm, calibrateScale, tareScale, getSensorCalibration, setSensorCalibration, getLastMachineSnapshot, ensureMachineSnapshotSocket, connectScaleWebSocket, setFirmwareFlashInFlight, persistSharedValue, MILK_STOP_LAST_VALUE_KEY, STEAM_DURATION_LAST_VALUE_KEY, STEAM_FLOW_LAST_VALUE_KEY, STEAM_TEMP_LAST_VALUE_KEY, HOT_WATER_VOLUME_LAST_VALUE_KEY, HOT_WATER_TEMP_LAST_VALUE_KEY, approvePluginUpdate, getPlugins, getDecentAccountStatus, getPluginSettings, setPluginSettings, callPluginEndpoint, enablePlugin } from '../modules/api.js';
+import {  getReaSettings, getDe1Settings, getDe1AdvancedSettings, setReaSettings, setDe1Settings, setDe1AdvancedSettings, resetDe1Settings, setMachineState, connectScaleDevice, connectDeviceWebSocket, sendDeviceCommand, awaitDeviceConnectResult, dimDisplay, restoreDisplay, isBlackScreenSaver, setBlackScreenSaver as apiSetBlackScreenSaver, rememberBrightness, getLastDisplayState, currentMachineState, signalHeartbeat, MachineState, getDeviceWebSocket, initDeviceWebSocketWithCallback, saveScaleDeviceId, getScaleDeviceId, connectDisplayWebSocket, sendDisplayCommand, connectUpdateWebSocket, sendUpdateCommand, enableWakeLock, disableWakeLock, isWakeLockEnabled, getPresenceSettings, setPresenceSettings, getPresenceSchedules, createPresenceSchedule, updatePresenceSchedule, deletePresenceSchedule, getAppInfo, getMachineInfo, getWorkflow, updateWorkflow, getAllSkins, getDefaultSkin, setDefaultSkin, updateSkins, stopWebuiServer, startWebuiServer, getWebuiServerStatus, uploadFirmware, applyFirmware, cancelFirmwareUpdate, getFirmwareCatalog, setWaterLevels, API_BASE_URL, listWifiScales, addWifiScale, removeWifiScale, forgetDevice, getLedStrip, setLedStrip, commitLedStrip, resetLedStrip, previewLedStrip, clearLedStripPreview, getCupWarmer, setCupWarmer, setCupWarmerPrewarm, calibrateScale, tareScale, getSensorCalibration, setSensorCalibration, getLastMachineSnapshot, ensureMachineSnapshotSocket, connectScaleWebSocket, setFirmwareFlashInFlight, persistSharedValue, MILK_STOP_LAST_VALUE_KEY, STEAM_DURATION_LAST_VALUE_KEY, STEAM_FLOW_LAST_VALUE_KEY, STEAM_TEMP_LAST_VALUE_KEY, HOT_WATER_VOLUME_LAST_VALUE_KEY, HOT_WATER_TEMP_LAST_VALUE_KEY, approvePluginUpdate, getPlugins, getDecentAccountStatus, getPluginSettings, setPluginSettings, callPluginEndpoint, enablePlugin, getShots } from '../modules/api.js';
 import * as ui from '../modules/ui.js';
 import { initScaling } from '../modules/scaling.js';
 import { getSupportedLanguages, getCurrentLanguage, setLanguage, translatePage, getTranslation } from '../modules/i18n.js';
@@ -5252,12 +5252,15 @@ export function pluginSettingLabel(key) {
         .trim();
 }
 
-// One control per manifest setting, for the two types shot-upload declares.
-// A type we have no control for renders nothing and is logged by the caller,
-// which is the signal to add it -- guessing at string/enum/secure widgets before
-// a plugin here asks for one is how this page drifted in the first place.
-export function renderPluginSettingControl(key, schema) {
-    const id = `shotupload-setting-${key}`;
+// One control per manifest setting, for the types the plugins on these pages
+// declare. A type we have no control for renders nothing and is logged by the
+// caller, which is the signal to add it -- guessing at widgets before a plugin
+// here asks for one is how this page drifted in the first place.
+//
+// `idPrefix` exists because more than one page renders a plugin's schema now
+// (Shot Uploader, Print The Shot); the ids have to stay distinct per page.
+export function renderPluginSettingControl(key, schema, idPrefix = 'shotupload') {
+    const id = `${idPrefix}-setting-${key}`;
     const label = escapeHtml(getTranslation(pluginSettingLabel(key)));
     const description = schema?.description
         ? `<p class="font-['Inter:Regular',sans-serif] font-normal leading-[1.4] not-italic relative text-[var(--text-primary)] text-[24px] w-full" data-i18n-key="${escapeHtml(schema.description)}">${escapeHtml(getTranslation(schema.description))}</p>`
@@ -5285,6 +5288,18 @@ export function renderPluginSettingControl(key, schema) {
                     <label for="${id}" class="text-[var(--text-primary)] text-[24px]">${label}</label>
                     <input type="number" id="${id}" min="0" data-setting-key="${escapeHtml(key)}" data-setting-type="number" class="w-24 p-3 rounded-lg border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[24px] focus:outline-none focus:ring-2 focus:ring-[var(--mimoja-blue)]">
                 </div>
+                ${description}
+            </div>`;
+    }
+
+    // `secure` is the manifest's own flag for a value that should not be read off
+    // the screen (visualizer's Password sets it) -- honour it rather than
+    // rendering every string in the clear.
+    if (schema?.type === 'string') {
+        return `
+            <div class="flex flex-col gap-[8px] w-full">
+                <label for="${id}" class="text-[var(--text-primary)] text-[24px]">${label}</label>
+                <input type="${schema.secure ? 'password' : 'text'}" id="${id}" data-setting-key="${escapeHtml(key)}" data-setting-type="string" class="w-full max-w-[500px] p-3 rounded-lg border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[24px] focus:outline-none focus:ring-2 focus:ring-[var(--mimoja-blue)]">
                 ${description}
             </div>`;
     }
@@ -5446,6 +5461,8 @@ function setupShotUploadListeners() {
                 let value;
                 if (type === 'boolean') {
                     value = this.checked;
+                } else if (type === 'string') {
+                    value = this.value;
                 } else {
                     value = parseFloat(this.value);
                     // Rejected rather than written: a NaN or a negative would be
@@ -5569,296 +5586,287 @@ export function renderExtensionsSettings() {
     return template;
 }
 
-// Print The Shot — settings UI for the bundled print-the-shot.reaplugin,
-// which uploads finished shots in TCL print format to a local print server.
-// Layout follows the other Extensions pages: native skin styling, stacked
-// vertically, with a plain-text shot browser instead of a chart.
+// Print The Shot -- settings UI for print-the-shot.reaplugin, which sends a
+// finished shot to a local print server that renders it as a paper receipt.
+//
+// The page owns none of the printing: which server, which path, how long a shot
+// has to be and whether finished shots go out automatically are the plugin's
+// settings, and the plugin subscribes to shot events itself. So this page is the
+// same shape as the Shot Uploader -- controls generated from the manifest schema
+// (see the note above renderShotUploadSettings for why they are not hand-written),
+// plus the one thing the plugin cannot offer on its own: picking which stored
+// shot to print, rather than only the last one.
 const PRINT_THE_SHOT_PLUGIN_ID = 'print-the-shot.reaplugin';
-const PRINT_THE_SHOT_DEFAULT_SETTINGS = {
-    AutoUpload: true,
-    ServerUrl: '',
-    ServerEndpoint: 'upload',
-    UseHttp: true,
-    MachineName: '',
-    MinSeconds: 6,
-};
-const PRINT_THE_SHOT_STATE = { offset: 0, shot: null, settings: null, processing: false };
+
+// Which stored shot the browser is sitting on, as an offset back from the most
+// recent. Module-level so returning to the page lands where it was left.
+let printTheShotOffset = 0;
+let printTheShotShot = null;
 
 export function renderPrintTheShotSettings() {
     setTimeout(setupPrintTheShotListeners, 0);
 
     return `
-        <div class="content-stretch flex flex-col gap-[40px] items-start relative w-full">
+        <div class="content-stretch flex flex-col gap-[60px] items-start relative w-full">
             <div class="flex flex-col font-['Inter:Semi_Bold',sans-serif] font-semibold justify-center leading-[0] min-w-full not-italic relative text-[var(--text-primary)] text-[36px] text-center w-[min-content]">
-                <p class="leading-[1.2]" data-i18n-key="Print The Shot">Print The Shot</p>
-                <p id="printtheshot-description" class="font-['Inter:Regular',sans-serif] font-normal leading-[1.4] not-italic relative text-[var(--text-primary)] text-[24px] w-full opacity-75"></p>
+                <p class="leading-[1.2]" id="printtheshot-title" data-i18n-key="Print The Shot">Print The Shot</p>
             </div>
 
-            <!-- Current shot -->
-            <div class="content-stretch flex flex-col gap-[16px] items-start relative w-full">
-                <div class="content-stretch flex items-center justify-between relative w-full">
-                    <button id="printtheshot-prev" class="bg-[#385a92] h-[52px] px-[22px] rounded-[64px] text-white text-[20px] font-bold" data-i18n-key="Previous shot">◀ Previous shot</button>
-                    <div class="flex flex-col items-center gap-[4px] flex-1 text-center px-[16px]">
-                        <p id="printtheshot-shot-title" class="text-[24px] font-bold text-[var(--text-primary)] leading-[1.2]">Loading…</p>
-                        <p id="printtheshot-shot-meta" class="text-[20px] text-[var(--low-contrast-white)] leading-[1.3]"></p>
+            <div class="content-stretch flex flex-col gap-[30px] items-start relative w-full">
+                <p id="printtheshot-description" class="text-[24px] text-[var(--text-primary)] leading-[1.4] opacity-75"></p>
+
+                <!-- Replaced with a notice when the plugin is missing or unreachable. -->
+                <div id="printtheshot-gate" class="w-full">
+                    <div class="flex items-center justify-center w-full py-[20px]">
+                        <span class="loading loading-spinner loading-lg text-[#385a92]"></span>
                     </div>
-                    <button id="printtheshot-next" class="bg-[#385a92] h-[52px] px-[22px] rounded-[64px] text-white text-[20px] font-bold" data-i18n-key="Next shot">Next shot ▶</button>
                 </div>
-            </div>
 
-            <!-- Settings -->
-            <div class="content-stretch flex flex-col gap-[24px] items-start relative w-full">
-                <div class="content-stretch flex flex-col gap-[14px] items-start relative w-full">
-                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-server-url" data-i18n-key="Server address">Server address</label>
-                    <input id="printtheshot-server-url" type="text" class="w-full max-w-[500px] p-[12px] rounded-[10px] border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[22px] focus:outline-none focus:ring-2 focus:ring-[#385a92]" placeholder="192.168.1.20:8000">
-                </div>
-                <div class="content-stretch flex flex-col gap-[14px] items-start relative w-full">
-                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-server-endpoint" data-i18n-key="Upload path">Upload path</label>
-                    <input id="printtheshot-server-endpoint" type="text" class="w-full max-w-[500px] p-[12px] rounded-[10px] border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[22px] focus:outline-none focus:ring-2 focus:ring-[#385a92]">
-                </div>
-                <div class="content-stretch flex flex-col gap-[14px] items-start relative w-full">
-                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-machine-name" data-i18n-key="Machine name">Machine name</label>
-                    <input id="printtheshot-machine-name" type="text" class="w-full max-w-[500px] p-[12px] rounded-[10px] border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[22px] focus:outline-none focus:ring-2 focus:ring-[#385a92]" placeholder="DE1">
-                </div>
-                <div class="content-stretch flex flex-col gap-[14px] items-start relative w-full">
-                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-min-seconds" data-i18n-key="Minimum shot length (s)">Minimum shot length (s)</label>
-                    <input id="printtheshot-min-seconds" type="number" min="0" class="w-full max-w-[300px] p-[12px] rounded-[10px] border border-[var(--border-color)] bg-[var(--profile-button-background-color)] text-[var(--text-primary)] text-[22px] focus:outline-none focus:ring-2 focus:ring-[#385a92]">
-                </div>
-                <div class="content-stretch flex items-center gap-[20px] relative w-full">
-                    <input id="printtheshot-use-http" type="checkbox" class="w-[36px] h-[36px] accent-[#385a92]">
-                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-use-http" data-i18n-key="Use HTTP">Use HTTP</label>
-                </div>
-                <div class="content-stretch flex items-center gap-[20px] relative w-full">
-                    <input id="printtheshot-auto-upload" type="checkbox" class="w-[36px] h-[36px] accent-[#385a92]">
-                    <label class="text-[var(--text-primary)] text-[22px]" for="printtheshot-auto-upload" data-i18n-key="Auto upload">Auto upload</label>
-                </div>
-            </div>
+                <!-- Filled from the manifest schema by setupPrintTheShotListeners. -->
+                <div id="printtheshot-controls" class="content-stretch flex flex-col gap-[30px] items-start relative w-full"></div>
 
-            <!-- Actions -->
-            <div class="content-stretch flex flex-wrap gap-[16px] items-center relative w-full">
-                <button id="printtheshot-print" class="bg-[#385a92] h-[56px] px-[28px] rounded-[64px] text-white text-[22px] font-bold" data-i18n-key="Print current shot">Print current shot</button>
-                <button id="printtheshot-upload-last" class="bg-[var(--profile-button-background-color)] border border-[var(--border-color)] h-[56px] px-[28px] rounded-[64px] text-[var(--text-primary)] text-[22px] font-bold" data-i18n-key="Upload last shot">Upload last shot</button>
-                <button id="printtheshot-save" class="bg-[var(--profile-button-background-color)] border border-[var(--border-color)] h-[56px] px-[28px] rounded-[64px] text-[var(--text-primary)] text-[22px] font-bold" data-i18n-key="Save settings">Save settings</button>
-                <span id="printtheshot-status" class="text-[20px] text-[var(--low-contrast-white)]"></span>
-            </div>
+                <!-- Shot picker. The plugin can only ever print "the last shot";
+                     this is how an older one gets printed. -->
+                <div class="content-stretch flex flex-col gap-[16px] items-start relative w-full">
+                    <div class="content-stretch flex items-center justify-between relative w-full">
+                        <button id="printtheshot-prev" class="bg-[#385a92] h-[52px] px-[22px] rounded-[64px] text-white text-[20px] font-bold">&#9664; <span data-i18n-key="Older">Older</span></button>
+                        <div class="flex flex-col items-center gap-[4px] flex-1 text-center px-[16px]">
+                            <p id="printtheshot-shot-title" class="text-[24px] font-bold text-[var(--text-primary)] leading-[1.2]" data-i18n-key="Loading">Loading</p>
+                            <p id="printtheshot-shot-meta" class="text-[20px] text-[var(--low-contrast-white)] leading-[1.3]"></p>
+                        </div>
+                        <button id="printtheshot-next" class="bg-[#385a92] h-[52px] px-[22px] rounded-[64px] text-white text-[20px] font-bold"><span data-i18n-key="Newer">Newer</span> &#9654;</button>
+                    </div>
+                </div>
 
-            <!-- Log -->
-            <div class="content-stretch flex flex-col gap-[10px] items-start relative w-full">
-                <div id="printtheshot-log" class="w-full min-h-[120px] max-h-[260px] overflow-y-auto p-[16px] rounded-[12px] border border-[var(--border-color)] bg-[var(--box-color)] text-[16px] leading-[1.5] text-[var(--text-primary)] font-mono"></div>
+                <div class="flex items-center gap-[14px] flex-wrap w-full">
+                    <button id="printtheshot-print" class="bg-[#385a92] h-[56px] px-[28px] rounded-[64px] text-white text-[22px] font-bold" data-i18n-key="Print this shot">Print this shot</button>
+                    <span id="printtheshot-status" class="text-[20px] text-[var(--text-primary)] opacity-60"></span>
+                </div>
             </div>
-        </div>`;
+        </div>
+    `;
 }
 
-async function setupPrintTheShotListeners() {
-    const $ = (id) => document.getElementById(id);
-    const logEl = $('printtheshot-log');
-    const statusEl = $('printtheshot-status');
-    if (!logEl) return;
+function setupPrintTheShotListeners() {
+    const gateEl = document.getElementById('printtheshot-gate');
+    const controlsEl = document.getElementById('printtheshot-controls');
+    if (!gateEl || !controlsEl) return;
 
-    const log = (msg, level = 'info') => {
-        const line = document.createElement('div');
-        const time = new Date().toISOString().slice(11, 19);
-        line.textContent = `${time}  ${msg}`;
-        line.style.color = level === 'error' ? '#f87171' : level === 'success' ? '#4ade80' : 'var(--text-primary)';
-        logEl.appendChild(line);
-        logEl.scrollTop = logEl.scrollHeight;
-        while (logEl.childElementCount > 100) logEl.removeChild(logEl.firstChild);
-    };
+    const printBtn = document.getElementById('printtheshot-print');
+    const prevBtn = document.getElementById('printtheshot-prev');
+    const nextBtn = document.getElementById('printtheshot-next');
+    const statusEl = document.getElementById('printtheshot-status');
+    const titleTextEl = document.getElementById('printtheshot-shot-title');
+    const metaEl = document.getElementById('printtheshot-shot-meta');
+
+    const notice = (title, body) => `
+        <div class="flex flex-col gap-[24px] p-[36px] rounded-[20px] border-2 border-dashed border-[var(--profile-button-outline-color)] bg-[var(--box-color)] items-center text-center">
+            <div class="flex flex-col gap-[8px]">
+                <p class="text-[26px] font-bold text-[var(--text-primary)]">${title}</p>
+                <p class="text-[22px] text-[var(--low-contrast-white)] max-w-[500px] leading-[1.4]">${body}</p>
+            </div>
+        </div>`;
 
     const setStatus = (text) => { if (statusEl) statusEl.textContent = text || ''; };
-    const pluginApi = (endpoint) => `${API_BASE_URL}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/${endpoint}`;
 
-    const plugins = await getPlugins();
-    const plugin = Array.isArray(plugins) ? plugins.find(p => p?.id === PRINT_THE_SHOT_PLUGIN_ID) : null;
-    if (!plugin) {
-        log('Print The Shot plugin not loaded — update Decaid', 'error');
-        setStatus('Plugin not loaded');
-        return;
-    }
-    const descriptionEl = $('printtheshot-description');
-    if (descriptionEl && plugin.description) descriptionEl.textContent = getTranslation(plugin.description);
-
-    try {
-        const res = await fetch(`${API_BASE_URL}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/settings`);
-        if (res.ok) PRINT_THE_SHOT_STATE.settings = Object.assign({}, PRINT_THE_SHOT_DEFAULT_SETTINGS, await res.json());
-    } catch (e) {
-        PRINT_THE_SHOT_STATE.settings = Object.assign({}, PRINT_THE_SHOT_DEFAULT_SETTINGS);
-        log('Failed to load settings: ' + e.message, 'error');
-    }
-    const s = PRINT_THE_SHOT_STATE.settings;
-    $('printtheshot-server-url').value = s.ServerUrl || '';
-    $('printtheshot-server-endpoint').value = s.ServerEndpoint || '';
-    $('printtheshot-machine-name').value = s.MachineName || '';
-    $('printtheshot-min-seconds').value = s.MinSeconds ?? 6;
-    $('printtheshot-use-http').checked = !!s.UseHttp;
-    $('printtheshot-auto-upload').checked = !!s.AutoUpload;
-
-    const fetchShotAt = async (offset) => {
-        try {
-            const res = await fetch(`${API_BASE_URL}/shots?limit=1&offset=${offset}`);
-            if (!res.ok) throw new Error('HTTP ' + res.status);
-            const data = await res.json();
-            return (data.items || [])[0] || null;
-        } catch (e) {
-            log('Failed to load shot: ' + e.message, 'error');
-            return null;
-        }
-    };
-
+    // The shot browser is the app's own feature, not the plugin's -- it keeps
+    // working (minus the print button) when the plugin is missing, rather than
+    // the whole page going dead.
     const showShot = (shot) => {
-        const titleEl = $('printtheshot-shot-title');
-        const metaEl = $('printtheshot-shot-meta');
-        if (!shot) { titleEl.textContent = 'No shots yet'; metaEl.textContent = ''; return; }
-        const wf = shot.workflow || {};
-        const when = new Date(shot.timestamp).toLocaleString();
-        const profile = (wf.profile && wf.profile.title) || '—';
-        const ann = shot.annotations || {};
-        const bean = ((shot.workflow || {}).context || {}).coffeeName || '';
-        titleEl.textContent = `${profile} · ${when}`;
-        metaEl.textContent = `in ${ann.actualDoseWeight ?? '?'}g · out ${ann.actualYield ?? '?'}g${bean ? ' · ' + bean : ''}`;
-    };
-
-    const loadShot = async () => {
-        const shot = await fetchShotAt(PRINT_THE_SHOT_STATE.offset);
+        if (!titleTextEl || !metaEl) return;
         if (!shot) {
-            if (PRINT_THE_SHOT_STATE.offset > 0) { log('No older shots', 'info'); PRINT_THE_SHOT_STATE.offset -= 1; }
-            else { log('Already at the latest shot', 'info'); }
+            titleTextEl.textContent = getTranslation('No shots yet');
+            titleTextEl.removeAttribute('data-i18n-key');
+            metaEl.textContent = '';
             return;
         }
-        PRINT_THE_SHOT_STATE.shot = shot;
-        showShot(shot);
+        const wf = shot.workflow || {};
+        const context = wf.context || {};
+        const when = new Date(shot.timestamp).toLocaleString();
+        const profile = wf.profile?.title || '—';
+        const ann = shot.annotations || {};
+        const bean = context.coffeeName || '';
+        titleTextEl.textContent = `${profile} · ${when}`;
+        titleTextEl.removeAttribute('data-i18n-key');
+        metaEl.textContent = `${getTranslation('in')} ${ann.actualDoseWeight ?? '?'}g · ${getTranslation('out')} ${ann.actualYield ?? '?'}g${bean ? ' · ' + bean : ''}`;
     };
 
-    const machineId = (name) => {
-        const clean = String(name || '').replace(/[^A-Za-z0-9]/g, '');
-        return clean ? clean.slice(0, 20) : 'UNKNOWN';
-    };
-
-    const uploadShot = async (shot) => {
-        if (!shot) { log('No shot selected', 'warn'); return; }
-        const settings = PRINT_THE_SHOT_STATE.settings;
-        if (!settings.ServerUrl) { log('No server configured — set Server address and save', 'error'); return; }
-        if (PRINT_THE_SHOT_STATE.processing) return;
-        PRINT_THE_SHOT_STATE.processing = true;
+    // Offsets are clamped against `total` so prev/next can be disabled at the
+    // ends instead of the user finding out by clicking into an empty page.
+    const loadShot = async () => {
+        let page;
         try {
-            const fullRes = await fetch(`${API_BASE_URL}/shots/${shot.id}`);
-            if (!fullRes.ok) throw new Error('HTTP ' + fullRes.status);
-            const full = await fullRes.json();
-            const ms = full.measurements || [];
-            let duration = 0;
-            if (ms.length >= 2) {
-                const first = ms[0].machine && ms[0].machine.timestamp;
-                const last = ms[ms.length - 1].machine && ms[ms.length - 1].machine.timestamp;
-                duration = first && last ? Math.round((new Date(last).getTime() - new Date(first).getTime()) / 1000) : Math.round(ms.length * 0.24);
-            }
-            if (duration < settings.MinSeconds) { log(`Shot too short (${duration}s < ${settings.MinSeconds}s), skipping`, 'warn'); return; }
+            page = await getShots({ limit: 1, offset: printTheShotOffset });
+        } catch (e) {
+            logger.warn('Print The Shot: could not read shot history', e);
+            if (titleTextEl) titleTextEl.textContent = getTranslation('Could not read shot history');
+            return;
+        }
+        if (!document.getElementById('printtheshot-shot-title')) return;
+        const total = page?.total ?? 0;
+        if (printTheShotOffset >= total && total > 0) {
+            printTheShotOffset = total - 1;
+            return loadShot();
+        }
+        printTheShotShot = (page?.items || [])[0] || null;
+        showShot(printTheShotShot);
+        if (prevBtn) prevBtn.disabled = printTheShotOffset >= total - 1;
+        if (nextBtn) nextBtn.disabled = printTheShotOffset <= 0;
+        if (printBtn) printBtn.disabled = !printTheShotShot || printBtn.dataset.pluginMissing === '1';
+    };
 
-            const ts = new Date().toISOString().replace(/[:.]/g, '').slice(0, 15);
-            const protocol = settings.UseHttp ? 'http' : 'https';
-            const server = String(settings.ServerUrl).replace(/^https?:[/][/]/, '');
-            const url = `${protocol}://${server}/${settings.ServerEndpoint}?machine_id=${machineId(settings.MachineName)}&timestamp=${ts}&plugin_version=${plugin.version}`;
+    prevBtn?.addEventListener('click', () => { printTheShotOffset += 1; loadShot(); });
+    nextBtn?.addEventListener('click', () => {
+        if (printTheShotOffset === 0) return;
+        printTheShotOffset -= 1;
+        loadShot();
+    });
 
-            log(`Printing shot ${shot.id.slice(0, 8)} → ${url}`, 'info');
-            for (let attempt = 1; attempt <= 3; attempt++) {
-                try {
-                    const res = await fetch(pluginApi('upload'), {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ url, shot: full }),
-                    });
-                    const data = await res.json();
-                    if (data && data.success) {
-                        log(`Print OK (attempt ${attempt})`, 'success');
-                        setStatus('OK');
+    (async () => {
+        if (printBtn) { printBtn.disabled = true; printBtn.dataset.pluginMissing = '1'; }
+        controlsEl.style.opacity = '0.4';
+        loadShot();
+
+        // getPlugins answers null when the request failed and [] when there really
+        // are none, so the two must not collapse into "not installed" -- that would
+        // tell a user with a working plugin to go and install it again.
+        const plugins = await getPlugins();
+        if (!document.getElementById('printtheshot-gate')) return;
+        if (!plugins) {
+            gateEl.innerHTML = notice(
+                getTranslation('Could not check'),
+                getTranslation("Couldn't reach the bridge to check the Print The Shot plugin."));
+            return;
+        }
+        const plugin = plugins.find(p => p?.id === PRINT_THE_SHOT_PLUGIN_ID);
+        if (!plugin) {
+            gateEl.innerHTML = notice(
+                getTranslation('Print The Shot plugin not installed'),
+                getTranslation('Decaid has no Print The Shot plugin installed. Install it on Decaid, then come back to set up printing.'));
+            return;
+        }
+
+        // The plugin names and explains itself. Both are optional on the wire, so
+        // the static header stands in if either is missing.
+        const titleEl = document.getElementById('printtheshot-title');
+        if (titleEl && plugin.name) {
+            titleEl.textContent = getTranslation(plugin.name);
+            titleEl.setAttribute('data-i18n-key', plugin.name);
+        }
+        const descriptionEl = document.getElementById('printtheshot-description');
+        if (descriptionEl && plugin.description) {
+            descriptionEl.textContent = getTranslation(plugin.description);
+            descriptionEl.setAttribute('data-i18n-key', plugin.description);
+        }
+
+        let settings;
+        try {
+            // Strict: the lenient default returns {} for a failed read, which would
+            // paint the controls at their defaults while printing is in fact set up.
+            settings = await getPluginSettings(PRINT_THE_SHOT_PLUGIN_ID, { strict: true }) || {};
+        } catch (e) {
+            logger.warn('Print The Shot settings unavailable:', e);
+            gateEl.innerHTML = notice(
+                getTranslation('Could not check'),
+                getTranslation("Couldn't read the Print The Shot settings. Reopen this page to try again."));
+            return;
+        }
+        // The page can be left while those awaits are in flight, which drops the
+        // form -- same hazard loadVisualizerSettings guards against.
+        if (!document.getElementById('printtheshot-controls')) return;
+
+        gateEl.innerHTML = '';
+
+        const schema = plugin.settings && typeof plugin.settings === 'object' ? plugin.settings : {};
+        const keys = Object.keys(schema);
+        controlsEl.innerHTML = keys.map(key => {
+            const html = renderPluginSettingControl(key, schema[key], 'printtheshot');
+            if (!html) logger.warn(`Print The Shot: no control for setting ${key} of type ${schema[key]?.type}`);
+            return html;
+        }).join('');
+
+        for (const key of keys) {
+            const el = document.getElementById(`printtheshot-setting-${key}`);
+            if (!el) continue;
+            const value = settings[key] !== undefined ? settings[key] : schema[key]?.default;
+            if (el.type === 'checkbox') el.checked = value === true;
+            else if (value !== undefined && value !== null) el.value = value;
+        }
+        controlsEl.style.opacity = '1';
+        translatePage();
+
+        controlsEl.querySelectorAll('[data-setting-key]').forEach(el => {
+            el.addEventListener('change', async function () {
+                const key = this.dataset.settingKey;
+                const type = this.dataset.settingType;
+                const previous = settings[key] !== undefined ? settings[key] : schema[key]?.default;
+
+                let value;
+                if (type === 'boolean') {
+                    value = this.checked;
+                } else if (type === 'string') {
+                    value = this.value.trim();
+                } else {
+                    value = parseFloat(this.value);
+                    // Rejected rather than written: a NaN or a negative would be
+                    // persisted and read back as a broken threshold on every later
+                    // load. The schema carries no bounds.
+                    if (!isFinite(value) || value < 0) {
+                        this.value = previous ?? '';
                         return;
                     }
-                    log(`Attempt ${attempt} failed: ${(data && data.message) || (data && data.statusCode ? 'HTTP ' + data.statusCode : 'HTTP ' + res.status)}`, 'warn');
-                } catch (e) {
-                    log(`Attempt ${attempt} error: ${e.message}`, 'warn');
                 }
-                if (attempt < 3) await new Promise(r => setTimeout(r, 2000));
-            }
-            log('Print FAILED after 3 attempts', 'error');
-            setStatus('FAILED');
-        } catch (e) {
-            log('Upload error: ' + e.message, 'error');
-        } finally {
-            PRINT_THE_SHOT_STATE.processing = false;
-        }
-    };
 
-    $('printtheshot-prev').addEventListener('click', () => { PRINT_THE_SHOT_STATE.offset += 1; loadShot(); });
-    $('printtheshot-next').addEventListener('click', () => {
-        if (PRINT_THE_SHOT_STATE.offset === 0) { log('Already at the latest shot', 'info'); return; }
-        PRINT_THE_SHOT_STATE.offset -= 1; loadShot();
-    });
-    $('printtheshot-print').addEventListener('click', () => uploadShot(PRINT_THE_SHOT_STATE.shot));
-    $('printtheshot-upload-last').addEventListener('click', async () => {
-        const shot = await fetchShotAt(0);
-        if (shot) { PRINT_THE_SHOT_STATE.offset = 0; PRINT_THE_SHOT_STATE.shot = shot; showShot(shot); uploadShot(shot); }
-    });
-    $('printtheshot-save').addEventListener('click', async () => {
-        const next = {
-            AutoUpload: $('printtheshot-auto-upload').checked,
-            ServerUrl: $('printtheshot-server-url').value.trim(),
-            ServerEndpoint: $('printtheshot-server-endpoint').value.trim() || 'upload',
-            UseHttp: $('printtheshot-use-http').checked,
-            MachineName: $('printtheshot-machine-name').value.trim(),
-            MinSeconds: parseInt($('printtheshot-min-seconds').value, 10) || 0,
-        };
-        try {
-            const res = await fetch(`${API_BASE_URL}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/settings`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(next),
-            });
-            if (!res.ok) throw new Error('HTTP ' + res.status);
-            PRINT_THE_SHOT_STATE.settings = next;
-            log('Settings saved', 'success');
-        } catch (e) {
-            log('Failed to save settings: ' + e.message, 'error');
-        }
-    });
-
-    // Auto-upload: subscribe to the plugin's events websocket (shotStored ids
-    // forwarded by the plugin). Uploads only run while this page is open.
-    let eventsWs = null;
-    let wsRetryTimer = null;
-    const scheduleWsReconnect = () => {
-        if (wsRetryTimer) return;
-        wsRetryTimer = setTimeout(() => { wsRetryTimer = null; connectEventsWs(); }, 5000);
-    };
-    const connectEventsWs = () => {
-        try {
-            eventsWs = new WebSocket(`${API_BASE_URL.replace(/^http/, 'ws').replace('/api/v1', '/ws/v1')}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/events`);
-        } catch (e) {
-            scheduleWsReconnect();
-            return;
-        }
-        eventsWs.onopen = () => log('Events connection live', 'success');
-        eventsWs.onerror = () => log('Events connection error', 'error');
-        eventsWs.onmessage = (evt) => {
-            try {
-                const msg = JSON.parse(evt.data);
-                if (msg && typeof msg.id === 'string') {
-                    log(`Shot stored: ${msg.id.slice(0, 8)}`, 'info');
-                    if (PRINT_THE_SHOT_STATE.settings && PRINT_THE_SHOT_STATE.settings.AutoUpload) {
-                        log('Auto-upload enabled — printing shot', 'info');
-                        uploadShot({ id: msg.id });
-                    } else {
-                        log('Auto-upload disabled — skipping', 'info');
+                this.disabled = true;
+                try {
+                    // A setting means nothing while the plugin is unloaded, so
+                    // switching one ON loads it first. Switching off leaves it
+                    // loaded: the manual print button still works.
+                    if (value === true && !plugin.loaded) {
+                        await enablePlugin(PRINT_THE_SHOT_PLUGIN_ID);
+                        plugin.loaded = true;
                     }
+                    await setPluginSettings(PRINT_THE_SHOT_PLUGIN_ID, { [key]: value });
+                    settings[key] = value;
+                    if (type === 'boolean') {
+                        ui.showToast(
+                            `${getTranslation(pluginSettingLabel(key))}: ${getTranslation(value ? 'On' : 'Off')}`,
+                            2000, 'success');
+                    }
+                } catch (e) {
+                    logger.error(`Failed to change Print The Shot setting ${key}`, e);
+                    ui.showToast(`${getTranslation('Failed')}: ${e.message || e}`, 4000, 'error');
+                    if (type === 'boolean') this.checked = previous === true;
+                    else this.value = previous ?? '';
                 }
-            } catch (e) {
-                log('Bad event payload', 'warn');
-            }
-        };
-        eventsWs.onclose = scheduleWsReconnect;
-    };
-    connectEventsWs();
+                this.disabled = false;
+            });
+        });
 
-    await loadShot();
-    log(`Print The Shot v${plugin.version} initialized`, 'info');
+        if (printBtn) {
+            delete printBtn.dataset.pluginMissing;
+            printBtn.disabled = !printTheShotShot;
+            printBtn.addEventListener('click', async function () {
+                if (!printTheShotShot) return;
+                this.disabled = true;
+                setStatus(`${getTranslation('Printing')}…`);
+                try {
+                    if (!plugin.loaded) { await enablePlugin(PRINT_THE_SHOT_PLUGIN_ID); plugin.loaded = true; }
+                    const result = await callPluginEndpoint(PRINT_THE_SHOT_PLUGIN_ID, 'upload', { shotId: printTheShotShot.id });
+                    // The endpoint answers 200 with ok:false for a shot it declined
+                    // to send (too short, no server configured), which is not a
+                    // transport failure and should not read as one.
+                    setStatus(result?.ok
+                        ? getTranslation('Printed')
+                        : `${getTranslation('Not printed')}: ${result?.error || getTranslation('skipped')}`);
+                } catch (e) {
+                    logger.error('Print The Shot failed', e);
+                    setStatus(`${getTranslation('Print failed')}: ${e.message || e}`);
+                }
+                this.disabled = false;
+            });
+        }
+    })();
 }
 
 // Render DYE2 (Describe Your Espresso 2) settings — its own Extensions sub-page.

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -5830,11 +5830,13 @@ async function setupPrintTheShotListeners() {
     };
     const connectEventsWs = () => {
         try {
-            eventsWs = new WebSocket(`${API_BASE_URL.replace(/^http/, 'ws')}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/events`);
+            eventsWs = new WebSocket(`${API_BASE_URL.replace(/^http/, 'ws').replace('/api/v1', '/ws/v1')}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/events`);
         } catch (e) {
             scheduleWsReconnect();
             return;
         }
+        eventsWs.onopen = () => log('Events connection live', 'success');
+        eventsWs.onerror = () => log('Events connection error', 'error');
         eventsWs.onmessage = (evt) => {
             try {
                 const msg = JSON.parse(evt.data);

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -5820,6 +5820,41 @@ async function setupPrintTheShotListeners() {
         }
     });
 
+    // Auto-upload: subscribe to the plugin's events websocket (shotStored ids
+    // forwarded by the plugin). Uploads only run while this page is open.
+    let eventsWs = null;
+    let wsRetryTimer = null;
+    const scheduleWsReconnect = () => {
+        if (wsRetryTimer) return;
+        wsRetryTimer = setTimeout(() => { wsRetryTimer = null; connectEventsWs(); }, 5000);
+    };
+    const connectEventsWs = () => {
+        try {
+            eventsWs = new WebSocket(`${API_BASE_URL.replace(/^http/, 'ws')}/plugins/${PRINT_THE_SHOT_PLUGIN_ID}/events`);
+        } catch (e) {
+            scheduleWsReconnect();
+            return;
+        }
+        eventsWs.onmessage = (evt) => {
+            try {
+                const msg = JSON.parse(evt.data);
+                if (msg && typeof msg.id === 'string') {
+                    log(`Shot stored: ${msg.id.slice(0, 8)}`, 'info');
+                    if (PRINT_THE_SHOT_STATE.settings && PRINT_THE_SHOT_STATE.settings.AutoUpload) {
+                        log('Auto-upload enabled — printing shot', 'info');
+                        uploadShot({ id: msg.id });
+                    } else {
+                        log('Auto-upload disabled — skipping', 'info');
+                    }
+                }
+            } catch (e) {
+                log('Bad event payload', 'warn');
+            }
+        };
+        eventsWs.onclose = scheduleWsReconnect;
+    };
+    connectEventsWs();
+
     await loadShot();
     log(`Print The Shot v${plugin.version} initialized`, 'info');
 }

--- a/test/plugin-list.test.mjs
+++ b/test/plugin-list.test.mjs
@@ -63,7 +63,7 @@ const shotUpload = (() => {
     const body = [
         lift(/function escapeHtml\(str\) \{[\s\S]*?\r?\n\}/, 'escapeHtml'),
         lift(/export function pluginSettingLabel\(key\) \{[\s\S]*?\r?\n\}/, 'pluginSettingLabel'),
-        lift(/export function renderPluginSettingControl\(key, schema\) \{[\s\S]*?\r?\n\}/, 'renderPluginSettingControl'),
+        lift(/export function renderPluginSettingControl\(key, schema, idPrefix = 'shotupload'\) \{[\s\S]*?\r?\n\}/, 'renderPluginSettingControl'),
     ].join('\n');
     // getTranslation is identity here: untranslated strings fall back to the
     // source string, so the manifest text is what reaches the page.
@@ -127,8 +127,25 @@ test('a type with no widget renders nothing rather than a broken control', () =>
     // The caller logs this, which is the prompt to add the widget. A half-drawn
     // control that silently discards writes would be worse than an absent one.
     assert.equal(shotUpload.renderPluginSettingControl('Roast', { type: 'enum', values: ['Light'] }), '');
-    assert.equal(shotUpload.renderPluginSettingControl('Odd', { type: 'string' }), '');
     assert.equal(shotUpload.renderPluginSettingControl('Missing', undefined), '');
+});
+
+test('a secure string is not rendered in the clear', () => {
+    // `secure` is the manifest's own flag (visualizer's Password sets it). A
+    // plain text input for it would put the value on a shared kitchen screen.
+    const open = shotUpload.renderPluginSettingControl('ServerUrl', { type: 'string' });
+    const secret = shotUpload.renderPluginSettingControl('Password', { type: 'string', secure: true });
+    assert.match(open, /type="text" id="shotupload-setting-ServerUrl"/);
+    assert.match(secret, /type="password" id="shotupload-setting-Password"/);
+});
+
+test('the id prefix keeps two pages rendering the same schema apart', () => {
+    // Shot Uploader and Print The Shot both draw a plugin's schema; colliding
+    // element ids would make each page read the other's control.
+    const shot = shotUpload.renderPluginSettingControl('AutoUpload', shotUploadSchema.AutoUpload);
+    const print = shotUpload.renderPluginSettingControl('AutoUpload', shotUploadSchema.AutoUpload, 'printtheshot');
+    assert.match(shot, /id="shotupload-setting-AutoUpload"/);
+    assert.match(print, /id="printtheshot-setting-AutoUpload"/);
 });
 
 test('manifest text is escaped, not injected', () => {


### PR DESCRIPTION
## Summary

Adds a "Print The Shot" entry to the Extensions settings, next to Visualizer, Shot Uploader, Plugins, and DYE2. The page embeds the `print-the-shot.reaplugin` settings UI using the skin's own styling (vertically stacked, native Tailwind controls — no iframe, no custom colors).

What the page provides:

- Plain-text shot browser (profile, timestamp, in/out, prev/next)
- Server/upload settings (Server address, Upload path, Machine name, Min seconds, Use HTTP, Auto upload) saved to the plugin settings store
- Print current shot / Upload last shot / Save settings actions
- Live log viewer
- Auto-upload of finished shots runs in the plugin backend (no page needed); the page adds live shot browsing and manual printing

## Verification

- `node --check` on the modified files
- Tested against a running Decaid (simulate mode): settings tree shows the new entry, page renders with skin theme, shot browsing works, printing uploads through the plugin proxy and the print server renders the receipt

## Impact

- New Extensions subcategory only; no changes to existing behavior



## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work.
