### PR TITLE
Plugins list: show a plugin's ui page as an "Open" button

### DIFF
--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -7320,7 +7320,7 @@ export async function initializeSettings({ initialMainCategory = null, initialCa
                         </div>
                         ${p.description ? `<p class="text-[22px] text-[var(--text-primary)] leading-[1.4] opacity-75">${escapeHtml(p.description)}</p>` : ''}
                         <span class="text-[18px] text-[var(--text-primary)] opacity-40 font-mono">${escapeHtml(p.id)}</span>
-                        ${uiUrl ? `<a href="${escapeHtml(uiUrl)}" class="text-[18px] text-[#385a92] underline font-mono break-words">${escapeHtml(uiUrl)}</a>` : ''}
+                        ${uiUrl ? `<a href="${escapeHtml(uiUrl)}" class="inline-flex items-center self-start bg-[#385a92] h-[56px] px-[36px] rounded-[56px] text-white text-[20px] font-bold no-underline mt-[8px]">Open</a>` : ''}
                     </div>
                     <div class="flex flex-col items-center gap-[6px] flex-shrink-0">
                         <label class="relative flex items-center cursor-pointer flex-shrink-0 w-[100px] h-[50px]">


### PR DESCRIPTION
The generic **Plugins** list (Settings → Extensions → Plugins) printed a plugin's `ui` endpoint as a raw URL:

```
http://localhost:8080/api/v1/plugins/dcamp.reaplugin/ui
```

This renders it as a styled **Open** button instead, so any plugin that ships its own page gets a clean, tappable action — with no per-plugin code in the skin. Examples:

- **dcamp** (`dcamp.reaplugin`) → opens the Decent community forum.
- **Decent shot upload** → opens its list of recently uploaded shots (each linking to the shot on decentespresso.com).

Only the `loadPluginList` render changes (one line): the `${uiUrl ? ... }` link markup goes from a raw-URL `<a>` to a pill button labelled `Open`. Behaviour is unchanged — it still navigates to the plugin's `ui` endpoint.

Part of a proposed cross-skin convention: skins surface a plugin's own `ui` page generically, rather than hand-coding a settings page per plugin. The Insight skin implements the same idea (opening the page in an in-skin overlay with a Back bar).

<img width="1790" height="1357" alt="Screenshot 2026-09-01 at 11 36 50" src="https://github.com/user-attachments/assets/5a74389d-238a-40db-9d1f-7704fee6a4b3" />

