### PR TITLE
feat(settings): load a chosen profile on machine wake

### DIFF
--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -2572,6 +2572,15 @@ export function isWakeLockEnabled() {
     return stored === null ? true : stored === 'true';
 }
 
+/** Load a chosen profile onto the machine when it wakes from sleep. Default OFF. */
+export function isWakeProfileEnabled() {
+    return localStorage.getItem('wakeProfileEnabled') === 'true';
+}
+
+export function getWakeProfileId() {
+    return localStorage.getItem('wakeProfileId') || '';
+}
+
 export async function enableWakeLock() {
     try {
         const response = await fetch(`${API_BASE_URL}/display/wakelock`, {

--- a/src/modules/app.js
+++ b/src/modules/app.js
@@ -753,6 +753,11 @@ function handleData(data) {
         logger.info('Machine woke from sleep. Reloading initial data.');
         loadInitialData();
 
+        if (api.isWakeProfileEnabled()) {
+            const wakeProfileId = api.getWakeProfileId();
+            if (wakeProfileId) profileManager.loadProfileForWake(wakeProfileId);
+        }
+
         // Hold off "[Reconnect]" — REA fires devices ws scanning ~3s after wake.
         // Show "Scanning..." until grace window expires or scanning flag arrives.
         if (!isScaleConnected) {

--- a/src/modules/profileManager.js
+++ b/src/modules/profileManager.js
@@ -574,6 +574,30 @@ export async function saveContextToActiveProfile(fields) {
     }
 }
 
+// Push a stored profile onto the machine using its own dose/yield defaults.
+// Used by the wake-lock "load profile on wake" setting, so it targets an
+// arbitrary profileId rather than activeProfileId.
+export async function loadProfileForWake(profileId) {
+    const profile = availableProfiles[profileId]?.profile;
+    if (!profile) {
+        logger.warn(`Wake profile ${profileId} not found — skipping.`);
+        return false;
+    }
+    const parsedDose = parseFloat(profile.dose_weight);
+    const defaultDose = isNaN(parsedDose) ? 18 : parsedDose;
+    const parsedYield = parseFloat(profile.target_weight);
+    const displayYield = isNaN(parsedYield) ? 0 : parsedYield;
+    try {
+        await updateWorkflow({ profile, context: { targetDoseWeight: defaultDose, targetYield: displayYield, grinderSetting: null } });
+        setActiveProfile(profileId);
+        logger.info(`Wake profile loaded: ${profileId}`);
+        return true;
+    } catch (error) {
+        logger.error('Failed to load wake profile:', error);
+        return false;
+    }
+}
+
 // Strip the user's saved overrides (dose/yield/grind) from the active profile's
 // metadata and re-apply the profile's own baked-in numbers to the machine + UI.
 export async function resetActiveProfileToDefaults() {

--- a/src/modules/settingsSync.js
+++ b/src/modules/settingsSync.js
@@ -39,6 +39,8 @@ export const SYNCED_KEYS = [
     'screensaverCycleSeconds',
     'blackScreenSaver',
     'wakeLockEnabled',
+    'wakeProfileEnabled',
+    'wakeProfileId',
     'waterTankUnit',
     'waterRefillLevel',
     'keyboardBindings',

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -1,6 +1,7 @@
 import { isEcoSteamEnabled, setEcoSteamEnabled } from '../modules/eco-steam.js';
-import {  getReaSettings, getDe1Settings, getDe1AdvancedSettings, setReaSettings, setDe1Settings, setDe1AdvancedSettings, resetDe1Settings, setMachineState, connectScaleDevice, connectDeviceWebSocket, sendDeviceCommand, awaitDeviceConnectResult, dimDisplay, restoreDisplay, isBlackScreenSaver, setBlackScreenSaver as apiSetBlackScreenSaver, rememberBrightness, getLastDisplayState, currentMachineState, signalHeartbeat, MachineState, getDeviceWebSocket, initDeviceWebSocketWithCallback, saveScaleDeviceId, getScaleDeviceId, connectDisplayWebSocket, sendDisplayCommand, connectUpdateWebSocket, sendUpdateCommand, enableWakeLock, disableWakeLock, isWakeLockEnabled, getPresenceSettings, setPresenceSettings, getPresenceSchedules, createPresenceSchedule, updatePresenceSchedule, deletePresenceSchedule, getAppInfo, getMachineInfo, getWorkflow, updateWorkflow, getAllSkins, getDefaultSkin, setDefaultSkin, updateSkins, stopWebuiServer, startWebuiServer, getWebuiServerStatus, uploadFirmware, applyFirmware, cancelFirmwareUpdate, getFirmwareCatalog, setWaterLevels, API_BASE_URL, listWifiScales, addWifiScale, removeWifiScale, forgetDevice, getLedStrip, setLedStrip, commitLedStrip, getCupWarmer, setCupWarmer, setCupWarmerPrewarm, calibrateScale, tareScale, getSensorCalibration, setSensorCalibration, getLastMachineSnapshot, ensureMachineSnapshotSocket, connectScaleWebSocket, setFirmwareFlashInFlight, persistSharedValue, MILK_STOP_LAST_VALUE_KEY, STEAM_DURATION_LAST_VALUE_KEY, STEAM_FLOW_LAST_VALUE_KEY, STEAM_TEMP_LAST_VALUE_KEY, HOT_WATER_VOLUME_LAST_VALUE_KEY, HOT_WATER_TEMP_LAST_VALUE_KEY, approvePluginUpdate, getPlugins, getDecentAccountStatus, getPluginSettings, setPluginSettings, callPluginEndpoint, enablePlugin } from '../modules/api.js';
+import {  getReaSettings, getDe1Settings, getDe1AdvancedSettings, setReaSettings, setDe1Settings, setDe1AdvancedSettings, resetDe1Settings, setMachineState, connectScaleDevice, connectDeviceWebSocket, sendDeviceCommand, awaitDeviceConnectResult, dimDisplay, restoreDisplay, isBlackScreenSaver, setBlackScreenSaver as apiSetBlackScreenSaver, rememberBrightness, getLastDisplayState, currentMachineState, signalHeartbeat, MachineState, getDeviceWebSocket, initDeviceWebSocketWithCallback, saveScaleDeviceId, getScaleDeviceId, connectDisplayWebSocket, sendDisplayCommand, connectUpdateWebSocket, sendUpdateCommand, enableWakeLock, disableWakeLock, isWakeLockEnabled, isWakeProfileEnabled, getWakeProfileId, getPresenceSettings, setPresenceSettings, getPresenceSchedules, createPresenceSchedule, updatePresenceSchedule, deletePresenceSchedule, getAppInfo, getMachineInfo, getWorkflow, updateWorkflow, getAllSkins, getDefaultSkin, setDefaultSkin, updateSkins, stopWebuiServer, startWebuiServer, getWebuiServerStatus, uploadFirmware, applyFirmware, cancelFirmwareUpdate, getFirmwareCatalog, setWaterLevels, API_BASE_URL, listWifiScales, addWifiScale, removeWifiScale, forgetDevice, getLedStrip, setLedStrip, commitLedStrip, getCupWarmer, setCupWarmer, setCupWarmerPrewarm, calibrateScale, tareScale, getSensorCalibration, setSensorCalibration, getLastMachineSnapshot, ensureMachineSnapshotSocket, connectScaleWebSocket, setFirmwareFlashInFlight, persistSharedValue, MILK_STOP_LAST_VALUE_KEY, STEAM_DURATION_LAST_VALUE_KEY, STEAM_FLOW_LAST_VALUE_KEY, STEAM_TEMP_LAST_VALUE_KEY, HOT_WATER_VOLUME_LAST_VALUE_KEY, HOT_WATER_TEMP_LAST_VALUE_KEY, approvePluginUpdate, getPlugins, getDecentAccountStatus, getPluginSettings, setPluginSettings, callPluginEndpoint, enablePlugin } from '../modules/api.js';
 import * as ui from '../modules/ui.js';
+import { availableProfiles, translateProfileTitle } from '../modules/profileManager.js';
 import { initScaling } from '../modules/scaling.js';
 import { getSupportedLanguages, getCurrentLanguage, setLanguage, translatePage, getTranslation } from '../modules/i18n.js';
 import { getTempUnit, setTempUnit, formatTemp, fromDisplayTemp, boundToDisplay } from '../modules/units.js';
@@ -2088,6 +2089,11 @@ export function renderWakeLockSettings() {
     // display-socket listener below for why that distinction matters.
     const wakeLockEnabled = displayStateCache?.wakeLockOverride
         ?? isWakeLockEnabled();
+    const wakeProfileEnabled = isWakeProfileEnabled();
+    const wakeProfileId = getWakeProfileId();
+    const profileOptions = Object.values(availableProfiles)
+        .map(record => `<option value="${escapeHtml(record.id)}" ${record.id === wakeProfileId ? 'selected' : ''}>${escapeHtml(translateProfileTitle(record.profile?.title) || record.id)}</option>`)
+        .join('');
 
     return `
         <div class="space-y-6 px-[60px] py-[80px]">
@@ -2113,6 +2119,32 @@ export function renderWakeLockSettings() {
                         <div class="absolute inset-0 rounded-full border-2 transition-colors duration-200 bg-[var(--toggle-off-bg)] border-[var(--toggle-off-border)] peer-checked:bg-[#385a92] peer-checked:border-[#385a92]"></div>
                         <div class="absolute top-1/2 left-[5px] -translate-y-1/2 peer-checked:translate-x-[46px] size-[40px] rounded-full transition-[transform,background-color] duration-200 bg-[var(--toggle-off-knob)] peer-checked:bg-white"></div>
                     </label>
+                </div>
+            </div>
+
+            <div class="bg-[var(--presence-card-bg)] rounded-lg p-6">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <label class="text-[24px] font-semibold text-[var(--presence-card-text)]" data-i18n-key="Load Profile on Wake">Load Profile on Wake</label>
+                        <p class="text-[18px] text-[var(--presence-card-text)] opacity-75 mt-1" data-i18n-key="Automatically load a chosen profile when the machine wakes from sleep">
+                            Automatically load a chosen profile when the machine wakes from sleep
+                        </p>
+                    </div>
+                    <label class="relative flex items-center cursor-pointer flex-shrink-0 w-[100px] h-[50px]">
+                        <input type="checkbox" id="wake-profile-toggle" class="sr-only peer"
+                               ${wakeProfileEnabled ? 'checked' : ''}
+                               onchange="handleWakeProfileToggle(this.checked)">
+                        <div class="absolute inset-0 rounded-full border-2 transition-colors duration-200 bg-[var(--toggle-off-bg)] border-[var(--toggle-off-border)] peer-checked:bg-[#385a92] peer-checked:border-[#385a92]"></div>
+                        <div class="absolute top-1/2 left-[5px] -translate-y-1/2 peer-checked:translate-x-[46px] size-[40px] rounded-full transition-[transform,background-color] duration-200 bg-[var(--toggle-off-knob)] peer-checked:bg-white"></div>
+                    </label>
+                </div>
+                <div id="wake-profile-select-row" class="mt-4" ${wakeProfileEnabled ? '' : 'hidden'}>
+                    <select id="wake-profile-select"
+                            class="select select-bordered w-full max-w-xs text-[20px] bg-[var(--presence-input-bg)] text-[var(--presence-input-text)] border-[var(--presence-input-border)]"
+                            onchange="handleWakeProfileSelect(this.value)">
+                        <option value="" data-i18n-key="Select a profile">Select a profile</option>
+                        ${profileOptions}
+                    </select>
                 </div>
             </div>
 
@@ -9580,6 +9612,19 @@ window.handleWakeLockToggle = async function(enabled) {
         console.error('Error toggling wake lock:', error);
         ui.showToast('Failed to toggle wake lock', 5000, 'error');
     }
+};
+
+window.handleWakeProfileToggle = function(enabled) {
+    localStorage.setItem('wakeProfileEnabled', enabled ? 'true' : 'false');
+    const row = document.getElementById('wake-profile-select-row');
+    if (row) row.hidden = !enabled;
+    if (enabled && !localStorage.getItem('wakeProfileId')) {
+        ui.showToast('Select a profile to load on wake', 3000, 'info');
+    }
+};
+
+window.handleWakeProfileSelect = function(profileId) {
+    localStorage.setItem('wakeProfileId', profileId);
 };
 
 // Presence Detection handlers


### PR DESCRIPTION
## Summary
- New off-by-default toggle in Wake Lock Settings: "Load Profile on Wake". Profile picker only appears once the toggle is on, so the page stays uncrowded.
- On wake (existing `wasSleeping` transition in `app.js`), the chosen profile is pushed to the machine via the same `updateWorkflow` path used when a profile is picked manually.
- New setting persists through the existing localStorage/KV settings-sync mirror alongside `wakeLockEnabled`.

## Test plan
- [x] `node --check` on all touched files
- [x] `node --test` — 688/689 pass (1 pre-existing failure unrelated to this change: missing gitignored `.tcl` fixture)
- [ ] Manual: toggle on in Settings > Wake Lock, pick a profile, put machine to sleep and wake it, confirm the profile loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)